### PR TITLE
Add layout gallery CI gates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,55 @@
+name: Validate Layout Gallery
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate layout-gallery contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Syntax and whitespace
+        run: |
+          node -c scripts/generate-patterns.mjs
+          node -c scripts/pattern-data.mjs
+          node -c scripts/validate-okf.mjs
+          node -c scripts/test-validate-okf.mjs
+          node -c scripts/validate-patterns.mjs
+          node -c scripts/test-validate-patterns.mjs
+          node -c scripts/validate-links.mjs
+          node -c scripts/validate-catalog.mjs
+          git diff --check
+
+      - name: Generated artifacts are current
+        run: |
+          node scripts/generate-patterns.mjs
+          git diff --exit-code
+
+      - name: OKF structure validation
+        run: |
+          node scripts/validate-okf.mjs --json
+          node scripts/test-validate-okf.mjs --json
+
+      - name: Pattern contract validation
+        run: |
+          node scripts/validate-patterns.mjs --min-count 30 --json
+
+      - name: Markdown link check
+        run: node scripts/validate-links.mjs --json
+
+      - name: Pattern count and category coverage
+        run: node scripts/validate-catalog.mjs --json
+
+      - name: Adversarial validator fixtures
+        run: node scripts/test-validate-patterns.mjs --json

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { patterns } from "./pattern-data.mjs";
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const root = process.cwd();
+const failures = [];
+
+function slugDir(category) {
+  return category.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+function read(relative) {
+  return fs.readFileSync(path.join(root, relative), "utf8");
+}
+
+function requireIncludes(relative, text) {
+  if (!read(relative).includes(text)) failures.push(`${relative}: missing ${text}`);
+}
+
+const expectedFiles = new Set();
+const expectedCategories = new Set();
+
+for (const [slug, category, problem] of patterns) {
+  const dir = slugDir(category);
+  const file = `patterns/${dir}/${slug}.md`;
+  expectedFiles.add(file);
+  expectedCategories.add(category);
+  if (!fs.existsSync(path.join(root, file))) failures.push(`missing pattern file: ${file}`);
+  requireIncludes("CATALOG.md", `- [${slug}](${file}) - ${category}: ${problem}`);
+  requireIncludes(`patterns/${dir}/index.md`, `- [${slug}](${slug}.md) - ${problem}`);
+}
+
+for (const category of expectedCategories) {
+  const dir = slugDir(category);
+  requireIncludes("patterns/index.md", `- [${category}](${dir}/index.md)`);
+}
+
+const actualFiles = fs.readdirSync(path.join(root, "patterns"), { recursive: true })
+  .filter((entry) => typeof entry === "string" && entry.endsWith(".md") && !entry.endsWith("index.md"))
+  .map((entry) => `patterns/${entry}`);
+
+for (const file of actualFiles) {
+  if (!expectedFiles.has(file)) failures.push(`unexpected pattern file: ${file}`);
+}
+
+const result = {
+  actualPatternCount: actualFiles.length,
+  expectedPatternCount: expectedFiles.size,
+  failures,
+  ok: failures.length === 0,
+};
+
+if (json) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (result.ok) {
+  console.log(`ok: ${actualFiles.length} cataloged patterns`);
+} else {
+  console.error(result.failures.join("\n"));
+}
+
+process.exit(result.ok ? 0 : 1);

--- a/scripts/validate-links.mjs
+++ b/scripts/validate-links.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const root = process.cwd();
+const failures = [];
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === ".git" || entry.name === ".omo" || entry.name === "node_modules") return [];
+    const next = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(next);
+    if (!entry.isFile() || !entry.name.endsWith(".md")) return [];
+    return [next];
+  });
+}
+
+function stripFencedCodeBlocks(content) {
+  return content.replace(/```[\s\S]*?```/g, "");
+}
+
+function localTarget(rawTarget) {
+  const target = rawTarget.trim();
+  if (!target || target.startsWith("#")) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return null;
+  return target.split("#")[0].split("?")[0];
+}
+
+function checkLink(file, target) {
+  const local = localTarget(target);
+  if (!local) return;
+  const decoded = decodeURIComponent(local);
+  const absolute = path.resolve(path.dirname(file), decoded);
+  if (!absolute.startsWith(root)) {
+    failures.push(`${path.relative(root, file)}: link escapes repository: ${target}`);
+    return;
+  }
+  if (!fs.existsSync(absolute)) failures.push(`${path.relative(root, file)}: missing link target: ${target}`);
+}
+
+const files = walk(root);
+for (const file of files) {
+  const content = stripFencedCodeBlocks(fs.readFileSync(file, "utf8"));
+  for (const match of content.matchAll(/(?<!!)\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)) {
+    checkLink(file, match[1]);
+  }
+}
+
+const result = {
+  checkedFiles: files.length,
+  failures,
+  ok: failures.length === 0,
+};
+
+if (json) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (result.ok) {
+  console.log(`ok: ${files.length} markdown files`);
+} else {
+  console.error(result.failures.join("\n"));
+}
+
+process.exit(result.ok ? 0 : 1);


### PR DESCRIPTION
## Summary
- Add GitHub Actions validation for all seven layout-gallery CI gates
- Add Markdown link validation
- Add pattern catalog/category coverage validation

## Verification
- node scripts/generate-patterns.mjs && git diff --exit-code
- node scripts/validate-okf.mjs --json
- node scripts/test-validate-okf.mjs --json
- node scripts/validate-patterns.mjs --min-count 30 --json
- node scripts/test-validate-patterns.mjs --json
- node scripts/validate-links.mjs --json
- node scripts/validate-catalog.mjs --json
- git diff --check