### PR TITLE
Add webpage generation workflow gate

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -12,6 +12,7 @@ Use this guide before a layout problem appears. It helps you classify a screen, 
 
 - **After a problem appears:** find a named pattern in `CATALOG.md` and port its HTML/CSS contract.
 - **Before a problem appears:** start with the screen type, answer the layout brief, then compose patterns from `recipes/`.
+- **When content needs to become a webpage:** use the [Webpage generation workflow](guides/webpage-generation-workflow.md) to classify the use case, make the content-to-layout match, run harmony evaluation, create the GPT Image reference, and record the implementation handoff before writing product CSS.
 
 ## Planning Flow
 
@@ -27,6 +28,7 @@ Use this guide before a layout problem appears. It helps you classify a screen, 
 
 - [Decision tree](guides/decision-tree.md): start here when you do not know the pattern name.
 - [Layout brief](guides/layout-brief.md): answer these questions before selecting a pattern stack.
+- [Webpage generation workflow](guides/webpage-generation-workflow.md): start here when content needs to become a homepage or ordinary webpage.
 - [Recipe index](recipes/index.md): screen-type compositions built from reusable patterns.
 - [Pattern catalog](CATALOG.md): individual layout primitives and their contracts.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each pattern documents one primary spatial problem and the smallest robust HTML/
 ## How To Use This Repository
 
 - Start with [Layout Planning Guide](GUIDE.md) when you are designing a screen before a layout problem is obvious.
+- Use the [Webpage Generation Workflow](guides/webpage-generation-workflow.md) when raw content needs to become a homepage or ordinary webpage before a layout recipe is obvious.
 - Use the [Decision Tree](guides/decision-tree.md) when you do not know the pattern name yet.
 - Fill out the [Layout Brief Template](guides/layout-brief.md) before choosing a pattern stack.
 - Use [Layout Recipes](recipes/index.md) when you need screen-level composition.

--- a/guides/decision-tree.md
+++ b/guides/decision-tree.md
@@ -81,3 +81,10 @@ Avoid multiple nested scroll containers unless each one has a named responsibili
 - Icons need a stable square slot: [icon-frame](../patterns/media-fit/icon-frame.md)
 - Overlay should not change document order: [imposter](../patterns/overlay-exception/imposter.md)
 - Regions intentionally occupy the same grid cell: [overlay-stack](../patterns/overlay-exception/overlay-stack.md)
+
+## Rejected Alternatives
+
+Rejected alternatives:
+
+- Record any recipe or pattern rejected because it weakens source order, focus order, scroll ownership, constraints, or content stress behavior.
+- Keep the reason in the [Layout brief](layout-brief.md) so the rejected option is visible during harmony evaluation and implementation handoff.

--- a/guides/layout-brief.md
+++ b/guides/layout-brief.md
@@ -50,6 +50,76 @@ Use this template before choosing patterns. The answer should describe spatial r
 - What happens with an unbroken string?
 - Does the layout survive `ltr` and `rtl` direction?
 
+## Webpage Generation Intake
+
+Use these fields when raw content must become a homepage or ordinary webpage before a pattern stack is obvious.
+
+Content-to-layout match:
+
+- What type of webpage is being made: homepage, campaign page, product page, article, documentation, portfolio, or support page?
+- Which content blocks are mandatory, optional, repeated, or disposable?
+- Which section job does each block serve: hook, explain, prove, compare, convert, navigate, or retain?
+- Which layout recipe is the closest spatial model, and which recipes were rejected?
+
+Harmony evaluation:
+
+- Does the section order match the visitor's decision path?
+- Does the visual weight match content priority before decoration is considered?
+- Do repeated regions share a rhythm without hiding unique content jobs?
+- Do accessibility, source order, and task completion override visual novelty where they conflict?
+
+GPT Image reference:
+
+- Required preconditions before prompt: use case, content blocks, section jobs, selected recipe, approved pattern stack, constraints, and harmony notes.
+- What image prompt will be generated from the approved content hierarchy and pattern stack?
+- Which details must the image clarify: hero composition, section rhythm, hierarchy, spacing, media treatment, or CTA priority?
+- Image review extract-vs-ignore: implementable hierarchy, spacing, media treatment, and CTA priority go into the handoff; decorative styling and proof-like claims stay out of reusable pattern CSS.
+- Which generated-image details are decorative and must not be copied into reusable pattern CSS?
+- Accepted image debt: record unclear areas that need another image, a written decision, or product-owner follow-up.
+- Which unclear generated-image details need a written decision, another reference, or explicit exclusion before implementation?
+
+Implementation handoff:
+
+- Which semantic HTML skeleton, layout patterns, constraints, and scroll owners are approved?
+- Which image-reference observations become product-level visual styling outside the pattern library?
+- Which viewport, content-stress, accessibility, and visual-evidence checks must pass before shipping?
+
+## Minimum Required Fields By Use Case
+
+Use the smallest field set that can keep source order, scroll ownership, and constraints from being overridden by visual taste or generated imagery.
+
+Homepage:
+
+- Content blocks, section jobs, closest recipe, pattern stack, scroll owner, constraints, harmony evaluation, GPT Image reference, implementation handoff.
+
+Dashboard:
+
+- Repeated panel inventory, scan or comparison task, closest recipe, pattern stack, scroll owner, constraints, harmony evaluation, GPT Image reference, implementation handoff.
+
+Article:
+
+- Reading path, supplemental content, closest recipe, pattern stack, scroll owner, constraints, harmony evaluation, GPT Image reference, implementation handoff.
+
+Form:
+
+- Input groups, validation and action placement, closest recipe, pattern stack, scroll owner, constraints, harmony evaluation, GPT Image reference, implementation handoff.
+
+Command surface:
+
+- Command regions, controlled content regions, closest recipe, pattern stack, scroll owner, constraints, harmony evaluation, GPT Image reference, implementation handoff.
+
+## Rejected Alternatives
+
+Record alternatives at the point they are rejected so the implementation handoff does not reopen them accidentally.
+
+```txt
+Rejected pattern or recipe:
+Reason rejected:
+Which requirement it weakened:
+Replacement:
+Accepted tradeoff:
+```
+
 ## Candidate Pattern Stack
 
 Record the initial pattern stack and why each pattern is responsible for a specific spatial problem.
@@ -64,4 +134,9 @@ Pattern stack:
 Constraints:
 Change points:
 Patterns rejected:
+Webpage use case:
+Section jobs:
+Harmony notes:
+GPT Image reference prompt:
+Implementation handoff:
 ```

--- a/guides/webpage-generation-workflow.md
+++ b/guides/webpage-generation-workflow.md
@@ -1,0 +1,179 @@
+---
+type: Planning Guide
+title: Webpage Generation Workflow
+description: Intake-to-implementation workflow for turning raw content into a homepage or ordinary webpage layout.
+---
+
+# Webpage Generation Workflow
+
+Use this workflow when the request is broad: "make a webpage," "make a homepage," "turn this content into a landing page," or any similar brief where the content exists before the layout model is clear.
+
+The workflow keeps two responsibilities separate:
+
+- `layout-gallery` chooses semantic structure, spatial model, constraints, pattern stack, scroll ownership, and verification.
+- The consuming product owns brand, typography, color, images, shadows, motion, generated visuals, and final styling.
+
+## Use Cases
+
+Start by naming the page use case, because the same content can imply different spatial models.
+
+- Homepage: introduce the offer, route visitors, prove credibility, and convert or continue exploration.
+- Campaign page: keep one narrative path and one primary conversion.
+- Product page: explain the product through feature, proof, comparison, and action sections.
+- Article or editorial page: preserve reading order and place supporting material near the relevant prose.
+- Portfolio or profile page: balance identity, selected work, proof, and contact routes.
+- Documentation or support page: prioritize wayfinding, search, stable navigation, and readable task content.
+
+If the use case is a homepage or marketing-style page, start from the [Homepage recipe](../recipes/homepage.md). If the content is mostly prose, compare it with [Article page](../recipes/article-page.md). If the content is task-heavy, compare it with [Command surface](../recipes/command-surface.md), [Form flow](../recipes/form-flow.md), or [List detail](../recipes/list-detail.md).
+
+## Content-to-Layout Match
+
+Translate content into section jobs before choosing CSS.
+
+1. Inventory the supplied content as blocks: headline, proof, features, media, pricing, FAQ, contact, navigation, legal, or support.
+2. Assign each block a job: hook, explain, prove, compare, convert, navigate, or retain.
+3. Choose the closest recipe by spatial model, not by product category.
+4. Check recipe requirements, then map each section job to reusable patterns: `cover` for first-viewport framing, `content-limiter` for readable copy, `stack` for vertical rhythm, `cluster` or `wrap-row` for actions, `ram-grid` or `card-grid` for repeated proof, `sidebar` or `sticky-aside` for nearby support.
+5. Reject patterns that only make the page look fashionable while weakening source order, focus order, scroll ownership, or content stress behavior.
+
+The output of this step is a candidate pattern stack with rejected alternatives named in the [Layout brief](layout-brief.md).
+
+## Workflow Route Examples
+
+Use these routes as trace examples before generating a GPT Image reference. Each route must preserve this order: content blocks become section jobs, section jobs choose a recipe, the recipe yields a pattern stack, scroll owner and constraints are named, harmony evaluation approves the contract, and only then can a GPT Image reference be generated.
+
+### Homepage Route
+
+Path: Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff
+
+- Content blocks: headline, offer explanation, proof, feature groups, comparison, CTA, footer navigation.
+- Section jobs: hook, explain, prove, compare, convert, navigate.
+- Recipe: [Homepage](../recipes/homepage.md).
+- Pattern stack: `cover`, `content-limiter`, `stack`, `cluster`, `ram-grid`, `frame`.
+- Scroll owner: normal document scroll; no nested scroll region unless a media reel has an explicit independent task.
+- Constraints: content measure, page gutters, section gaps, repeat-grid minimums, media ratios, and CTA wrapping thresholds.
+- Rejected alternatives: dashboard, article, form, command surface, or list-detail recipes when the content is primarily promotional and decision-path based.
+
+### Dashboard Route
+
+Path: Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff
+
+- Content blocks: page title, filters, status panels, metrics, repeated workflow cards, primary actions.
+- Section jobs: orient, filter, scan, compare, act.
+- Recipe: [Dashboard](../recipes/dashboard.md).
+- Pattern stack: `page-grid`, `card-grid`, `cluster`, with `ram-grid` or `dense-grid` only when repeated panels need them.
+- Scroll owner: normal document scroll unless a declared panel has independent scroll state.
+- Constraints: page gutters, panel gaps, minimum panel widths, action wrapping, and any fixed panel block size.
+- Rejected alternatives: homepage framing when the primary task is repeated scan-and-compare work, or form flow when panels must remain comparable.
+
+### Article Route
+
+Path: Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff
+
+- Content blocks: title, deck, prose sections, figures, references, supplemental aside, related links.
+- Section jobs: orient, read, reference, retain.
+- Recipe: [Article page](../recipes/article-page.md).
+- Pattern stack: `content-limiter`, `sticky-aside`, `stack`, with `sidebar` only when support content must sit near prose.
+- Scroll owner: document scroll; aside stickiness cannot create an unnamed nested scroll region.
+- Constraints: readable measure, section gaps, local prose gaps, figure ratios, and aside width or collapse point.
+- Rejected alternatives: homepage or dashboard recipes when the primary task is sequential reading.
+
+### Form Route
+
+Path: Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff
+
+- Content blocks: form title, instructions, field groups, validation messages, primary and secondary actions, help text.
+- Section jobs: orient, collect, validate, submit, recover.
+- Recipe: [Form flow](../recipes/form-flow.md).
+- Pattern stack: `content-limiter`, `stack`, `cluster`, with `sticky-footer` only when persistent actions do not hide errors or focus targets.
+- Scroll owner: document scroll unless a shell owns a named body scroll area.
+- Constraints: form measure, field gaps, group gaps, action gaps, wrapping thresholds, and validation-message space.
+- Rejected alternatives: dashboard or command-surface layouts when the task is a sequential input flow.
+
+### Command Surface Route
+
+Path: Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff
+
+- Content blocks: command bar, navigation or mode switcher, primary work area, inspector or supporting pane, status feedback.
+- Section jobs: orient, command, inspect, edit, confirm.
+- Recipe: [Command surface](../recipes/command-surface.md).
+- Pattern stack: `scroll-body-shell`, `split-nav`, `wrap-row`, with `reel` only when horizontal command scanning is intentional.
+- Scroll owner: shell body owns content scrolling; fixed command regions stay outside the body scroll container.
+- Constraints: shell height, command gaps, command wrapping behavior, pane widths, and overflow responsibilities.
+- Rejected alternatives: homepage, article, or form flow recipes when stable commands and controlled regions define the task.
+
+## Harmony Evaluation
+
+Run harmony evaluation before generating images or writing implementation CSS. Use the [Harmony evaluation gate](../quality/gates/harmony-evaluation.md) for the claim shape.
+
+Check:
+
+- Content hierarchy: the section order follows the visitor's decision path.
+- Spatial rhythm: repeated sections share a rhythm, while sections with different jobs have distinct scale or grouping.
+- Weight balance: primary content receives visual weight before supporting content and decoration.
+- Constraint fit: gutters, section gaps, readable measures, media ratios, and grid minimums support real content.
+- Accessibility precedence: semantic order, focus order, keyboard routes, reduced-motion needs, and readable text override visual novelty.
+- Pattern boundary: reusable pattern CSS remains layout-only; brand and generated-image styling stay in the consuming product.
+
+If the harmony claim fails, revise the content map or pattern stack before generating the visual reference.
+
+## GPT Image Reference
+
+Generate the GPT Image reference only after the use case, section jobs, semantic skeleton, pattern stack, and harmony notes are approved.
+
+Required preconditions before prompt:
+
+- use case, audience, content blocks, and section jobs are recorded;
+- recipe, semantic skeleton, pattern stack, scroll owner, constraints, and harmony notes are approved.
+
+The image prompt should include:
+
+- page use case and audience;
+- section list with each section job;
+- approved semantic order and pattern stack;
+- required hierarchy, spacing, media ratio, CTA priority, and scroll behavior;
+- accessibility constraints that the image must respect;
+- instruction to keep the render implementation-friendly and readable;
+- instruction that decorative styling is product-level and not part of reusable pattern CSS.
+
+Generate one clear homepage or section reference image when the page is short. For a larger homepage, generate section-level references so text, spacing, and hierarchy remain inspectable.
+
+After generation, review the image with this extract-vs-ignore split:
+
+Extract from image:
+
+- section rhythm, hierarchy, approximate spacing, media treatment, and CTA priority;
+- unclear areas that need another image or a written decision;
+
+Ignore from image:
+
+- decorative choices that belong to the consuming product, not this pattern library.
+- claims about source order, focus order, accessibility, usability, brand correctness, or implementation correctness.
+
+Do not treat a generated image as proof of usability, accessibility, or brand fit. It is a visual reference that still needs quality gates and real implementation verification.
+
+## Implementation Handoff
+
+Before implementation, hand off a compact contract:
+
+```txt
+Use case:
+Primary task:
+Audience:
+Section jobs:
+Semantic HTML skeleton:
+Pattern stack:
+Scroll owner:
+Constraints and change points:
+Harmony evaluation:
+GPT Image reference:
+Image observations to implement:
+Image observations to ignore:
+Accessibility checks:
+Viewport/content stress checks:
+Implementation debt:
+Final implementation proof:
+Accepted debt:
+```
+
+The implementer builds from semantic HTML and layout patterns first, then applies product-level visual styling from the image reference outside reusable pattern CSS. The final page must still pass layout stress checks, accessibility evidence, and any visual-evidence protocol declared by the consuming product.

--- a/quality/gates/harmony-evaluation.md
+++ b/quality/gates/harmony-evaluation.md
@@ -1,0 +1,73 @@
+---
+type: Quality Gate
+title: Harmony Evaluation Gate
+description: Contract for judging webpage content-to-layout fit, visual-reference use, and implementation handoff.
+---
+
+# Harmony Evaluation Gate
+
+Use this gate before a generated image or visual reference becomes implementation guidance for a homepage or ordinary webpage.
+
+## Required Contract
+
+Record:
+
+```txt
+Use case:
+Primary task:
+Audience:
+Content-to-layout match:
+Overall harmony:
+Claim record route:
+GPT Image reference:
+Implementation handoff:
+Rejected alternatives:
+Final implementation proof:
+Evidence family:
+Verification protocol:
+Boundary or limitation:
+Decision:
+```
+
+Do not generate a GPT Image reference before harmony evaluation approves the semantic order, section jobs, pattern stack, scroll owner, and constraints.
+Source order, accessibility, brand correctness, and usability cannot be inferred from the image.
+Final implementation proof: screenshot or visual-diff evidence, accessibility evidence, and viewport/content stress evidence from the built page.
+
+## Evidence Families
+
+Use these evidence family names:
+
+- `validator`: layout brief fields, recipe choice, pattern stack, semantic skeleton, linkable workflow docs, and validator output.
+- `screenshot`: generated GPT Image reference, screenshots, state captures, viewport captures, and visual diffs.
+- `accessibility`: keyboard order, focus visibility, contrast, reduced-motion, semantic landmarks, assistive-technology review, and cognitive accessibility review.
+- `user`: content hierarchy review, cognitive walkthrough, visitor decision-path review, design critique, participant testing, or validated measurement.
+- `source`: external methodology or standards used to frame the harmony claim.
+- `rationale`: claim record, rejected alternatives, limitations, accepted debt, owner, and review trigger.
+
+## Blocking Conditions
+
+Block the harmony claim when:
+
+- the use case is unnamed;
+- the page uses a fashionable layout that does not match the content jobs;
+- the GPT Image reference is generated before semantic order, section jobs, and pattern stack are approved;
+- the GPT Image reference is generated before scroll owner and constraints are approved;
+- rejected alternatives are missing when a fashionable or image-led pattern was considered;
+- a generated image is treated as proof of usability, accessibility, or brand fit;
+- visual novelty weakens source order, focus order, task completion, or content stress behavior;
+- decorative styling is moved into reusable pattern CSS;
+- the implementation handoff omits constraints, scroll ownership, accepted debt, or verification.
+
+## Accessibility Boundary
+
+Generated images, screenshots, visual diffs, and GPT Image references cannot prove accessibility. They can show rendered state, hierarchy, or visual intent, but accessibility claims must link to the accessibility evidence register and name an `automated`, `manual`, `user`, or `debt` verification method.
+
+## Boundary
+
+This gate decides whether a webpage composition is coherent enough to guide implementation. It does not define the consuming product's brand, typography, color, illustration style, animation system, or component library.
+
+Use a structured claim record when the harmony decision approves, blocks, or redirects implementation. Harmony records must include the use case and implementation handoff because they decide what the implementer may safely carry from a visual reference into product-level styling.
+
+## IA Navigation
+
+Parent: [Gate Contracts](index.md).

--- a/quality/gates/index.md
+++ b/quality/gates/index.md
@@ -1,0 +1,7 @@
+# Gate Contracts
+
+Gate contracts define what kind of evidence can support a claim.
+
+## Gates
+
+- [Harmony evaluation gate](harmony-evaluation.md) - Contract for judging content-to-layout fit, overall harmony, GPT Image references, and implementation handoff.

--- a/recipes/homepage.md
+++ b/recipes/homepage.md
@@ -1,0 +1,89 @@
+---
+type: Layout Recipe
+title: Homepage
+description: Compose raw content into a homepage or ordinary webpage before product-level visual styling.
+screen_type: Homepage
+primary_user_task: Understand the offer, find the right next path, and decide whether to act.
+spatial_model: First-viewport hook followed by stacked explanation, proof, comparison, conversion, and navigation sections.
+---
+
+# Homepage
+
+Use this recipe when raw content needs to become a homepage, landing page, campaign page, or general webpage and no narrower recipe has been chosen yet.
+
+## Recommended Pattern Stack
+
+- [cover](../patterns/viewport-shell/cover.md)
+- [content-limiter](../patterns/containment/content-limiter.md)
+- [stack](../patterns/stacking/stack.md)
+- [cluster](../patterns/in-line-grouping/cluster.md)
+- [ram-grid](../patterns/grid-repetition/ram-grid.md)
+- [frame](../patterns/media-fit/frame.md)
+
+## Content-To-Layout Matching
+
+Map content blocks to section jobs before selecting visual treatment.
+
+- Hook: use `cover` or a constrained first section when the opening message needs viewport-level framing.
+- Explain: use `content-limiter` and `stack` for readable copy and progressive disclosure.
+- Prove: use `ram-grid`, `card-grid`, or `columns` for testimonials, metrics, logos, examples, or repeated evidence.
+- Compare: use a grid or sidebar composition only when comparisons need alignment or nearby support.
+- Convert: use `cluster` or `wrap-row` for CTA groups that must wrap before overflow.
+- Navigate or retain: use footer, link clusters, or repeated navigation groups after the primary action path.
+
+Reject this recipe when the page is primarily a document, dashboard, form, command surface, or list-detail workflow.
+
+## DOM And Source Order
+
+Order sections by the visitor's decision path, not by visual symmetry. Put the primary heading, explanation, proof, and action in semantic order before layout classes. Repeated proof should be a list when each item has the same role.
+
+## Scroll Ownership
+
+Prefer normal document scrolling. Avoid nested scroll regions unless a section has an explicit independent task, such as a horizontally scrolling media reel with named keyboard and overflow behavior.
+
+## Accessibility Expectations
+
+- Focus expectation: Navigation, primary CTA, proof links, and conversion actions follow the visitor decision path declared in DOM order.
+- Scroll expectation: Any carousel, reel, sticky CTA, or first-viewport treatment must declare keyboard access and avoid hiding focused content.
+- Cognitive risk: Marketing hierarchy can overstate meaning visually; headings, section jobs, and CTA labels must make the same path understandable without the generated image.
+
+## Responsive Behavior
+
+Let sections collapse through intrinsic sizing, content limits, wrapping action rows, and repeat grids before adding viewport breakpoints. Keep the first viewport readable on narrow screens; do not require a generated hero image to carry essential text.
+
+## Constraints And Change Points
+
+Declare content measure, section gaps, page gutters, repeat-grid minimums, media ratios, and CTA wrapping thresholds. Treat brand color, typography, shadows, borders, and motion as product-level decisions outside this recipe.
+
+## GPT Image Reference
+
+Use the [Webpage Generation Workflow](../guides/webpage-generation-workflow.md) before generating the GPT Image reference. The prompt should describe the approved semantic order, section jobs, pattern stack, constraints, and harmony notes. After generation, extract hierarchy, spacing, media treatment, and CTA priority; keep decorative styling in the consuming product.
+
+Required preconditions before prompt:
+
+- Use case, audience, section jobs, semantic order, pattern stack, scroll owner, constraints, and harmony evaluation are approved.
+
+Image review extract-vs-ignore:
+
+- Extract section rhythm, hierarchy, approximate spacing, media treatment, and CTA priority.
+- Ignore decorative choices that belong to the consuming product or conflict with source order, accessibility, constraints, or content stress behavior.
+
+## Harmony Evaluation
+
+Use the [Harmony evaluation gate](../quality/gates/harmony-evaluation.md) before implementation. If hierarchy, rhythm, accessibility, or source order conflict with the visual reference, the layout contract wins and the image prompt should be regenerated.
+
+## When Not To Use
+
+Do not use this recipe to force marketing-page structure onto task-heavy apps, documentation, long articles, settings, or list-detail workflows.
+
+## Related Patterns
+
+- [page-grid](../patterns/grid-repetition/page-grid.md)
+- [card-grid](../patterns/grid-repetition/card-grid.md)
+- [sidebar](../patterns/split-sidebar/sidebar.md)
+- [sticky-footer](../patterns/viewport-shell/sticky-footer.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Gate Contracts](../quality/gates/index.md) for claim checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/index.md
+++ b/recipes/index.md
@@ -2,6 +2,7 @@
 
 Recipes combine layout patterns into screen-level spatial models.
 
+- [Homepage](homepage.md) - Content-led webpage composition with hero, proof, explanation, conversion, and navigation sections.
 - [SaaS settings](saas-settings.md) - Fixed navigation with a constrained settings flow.
 - [Dashboard](dashboard.md) - Repeated metric and panel regions on a page grid.
 - [Article page](article-page.md) - Readable prose with supporting aside content.

--- a/scripts/test-validate-webpage-workflow.mjs
+++ b/scripts/test-validate-webpage-workflow.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const validator = path.join(root, "scripts", "validate-webpage-workflow.mjs");
+
+const files = {
+  "README.md": "# layout-gallery\n\n- [Webpage Generation Workflow](guides/webpage-generation-workflow.md)\n",
+  "GUIDE.md": [
+    "# Layout Planning Guide",
+    "",
+    "- [Webpage generation workflow](guides/webpage-generation-workflow.md)",
+    "- content-to-layout match",
+    "- harmony evaluation",
+    "- GPT Image reference",
+    "- implementation handoff",
+    "",
+  ].join("\n"),
+  "guides/layout-brief.md": [
+    "# Layout Brief Template",
+    "",
+    "## Webpage Generation Intake",
+    "",
+    "Content-to-layout match:",
+    "Harmony evaluation:",
+    "GPT Image reference:",
+    "Required preconditions before prompt:",
+    "Image review extract-vs-ignore:",
+    "Implementation handoff:",
+    "Accepted image debt:",
+    "",
+    "## Minimum Required Fields By Use Case",
+    "",
+    "Homepage:",
+    "Dashboard:",
+    "Article:",
+    "Form:",
+    "Command surface:",
+    "",
+    "## Rejected Alternatives",
+    "",
+    "Rejected pattern or recipe:",
+    "Reason rejected:",
+    "",
+  ].join("\n"),
+  "guides/decision-tree.md": [
+    "# Layout Decision Tree",
+    "",
+    "Rejected alternatives:",
+    "",
+  ].join("\n"),
+  "guides/webpage-generation-workflow.md": [
+    "---",
+    "type: Planning Guide",
+    "---",
+    "",
+    "# Webpage Generation Workflow",
+    "",
+    "## Use Cases",
+    "## Content-to-Layout Match",
+    "## Harmony Evaluation",
+    "## GPT Image Reference",
+    "Required preconditions before prompt:",
+    "Extract from image:",
+    "Ignore from image:",
+    "## Implementation Handoff",
+    "Implementation debt:",
+    "Final implementation proof:",
+    "## Workflow Route Examples",
+    "",
+    "### Homepage Route",
+    "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+    "",
+    "### Dashboard Route",
+    "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+    "",
+    "### Article Route",
+    "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+    "",
+    "### Form Route",
+    "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+    "",
+    "### Command Surface Route",
+    "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+    "",
+  ].join("\n"),
+  "recipes/index.md": "# Layout Recipes\n\n- [Homepage](homepage.md)\n",
+  "recipes/homepage.md": [
+    "---",
+    "type: Layout Recipe",
+    "screen_type: Homepage",
+    "---",
+    "",
+    "# Homepage",
+    "",
+    "## Recommended Pattern Stack",
+    "## Content-To-Layout Matching",
+    "## GPT Image Reference",
+    "Required preconditions before prompt:",
+    "Image review extract-vs-ignore:",
+    "",
+  ].join("\n"),
+  "quality/gates/index.md": "# Gate Contracts\n\n- [Harmony evaluation gate](harmony-evaluation.md)\n",
+  "quality/gates/harmony-evaluation.md": [
+    "---",
+    "type: Quality Gate",
+    "---",
+    "",
+    "# Harmony Evaluation Gate",
+    "",
+    "## Required Contract",
+    "",
+    "Content-to-layout match:",
+    "Overall harmony:",
+    "GPT Image reference:",
+    "Implementation handoff:",
+    "Rejected alternatives:",
+    "Do not generate a GPT Image reference before harmony evaluation approves the semantic order, section jobs, pattern stack, scroll owner, and constraints.",
+    "Source order, accessibility, brand correctness, and usability cannot be inferred from the image.",
+    "Final implementation proof:",
+    "",
+  ].join("\n"),
+};
+
+const cases = [
+  {
+    name: "missing_workflow_file",
+    omit: ["guides/webpage-generation-workflow.md"],
+    expect: "guides/webpage-generation-workflow.md: missing file",
+  },
+  {
+    name: "missing_harmony_anchor",
+    mutate: {
+      "quality/gates/harmony-evaluation.md": files["quality/gates/harmony-evaluation.md"].replace("Overall harmony:", "Overall fit:"),
+    },
+    expect: "quality/gates/harmony-evaluation.md: missing Overall harmony:",
+  },
+  {
+    name: "missing_route_examples",
+    mutate: {
+      "guides/webpage-generation-workflow.md": files["guides/webpage-generation-workflow.md"].replace("## Workflow Route Examples", "## Workflow Routes"),
+    },
+    expect: "guides/webpage-generation-workflow.md: missing ## Workflow Route Examples",
+  },
+  {
+    name: "missing_image_proof_boundary",
+    mutate: {
+      "quality/gates/harmony-evaluation.md": files["quality/gates/harmony-evaluation.md"].replace(
+        "Source order, accessibility, brand correctness, and usability cannot be inferred from the image.",
+        "Generated image alone is enough for source order and access decisions.",
+      ),
+    },
+    expect: "quality/gates/harmony-evaluation.md: missing Source order, accessibility, brand correctness, and usability cannot be inferred from the image.",
+  },
+  {
+    name: "misordered_gpt_image_route",
+    mutate: {
+      "guides/webpage-generation-workflow.md": files["guides/webpage-generation-workflow.md"].replace(
+        "Content blocks -> Section jobs -> Recipe -> Pattern stack -> Scroll owner -> Constraints -> Harmony evaluation -> GPT Image reference -> Implementation handoff",
+        "Content blocks -> Section jobs -> Recipe -> Pattern stack -> GPT Image reference -> Harmony evaluation -> Scroll owner -> Constraints -> Implementation handoff",
+      ),
+    },
+    expect: "guides/webpage-generation-workflow.md: route Homepage places GPT Image reference before Harmony evaluation",
+  },
+  {
+    name: "missing_rejected_alternatives",
+    mutate: {
+      "guides/layout-brief.md": files["guides/layout-brief.md"].replace("## Rejected Alternatives", "## Alternatives"),
+    },
+    expect: "guides/layout-brief.md: missing ## Rejected Alternatives",
+  },
+  {
+    name: "success_path",
+    expect: null,
+  },
+];
+
+function writeFixture(testCase) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `layout-gallery-webpage-workflow-${testCase.name}-`));
+  const omitted = new Set(testCase.omit ?? []);
+  const entries = { ...files, ...(testCase.mutate ?? {}) };
+  for (const [relative, content] of Object.entries(entries)) {
+    if (omitted.has(relative)) continue;
+    const target = path.join(dir, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return dir;
+}
+
+function runCase(testCase) {
+  const dir = writeFixture(testCase);
+  const result = spawnSync(process.execPath, [validator, "--json"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  fs.rmSync(dir, { force: true, recursive: true });
+  const output = JSON.parse(result.stdout);
+  const passed = testCase.expect ? !output.ok && output.failures.includes(testCase.expect) : output.ok;
+  return {
+    name: testCase.name,
+    ok: passed,
+    expected: testCase.expect ?? "ok:true",
+    actual: output,
+  };
+}
+
+const results = cases.map(runCase);
+const report = {
+  ok: results.every((result) => result.ok),
+  results,
+};
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(report.ok ? 0 : 1);

--- a/scripts/validate-webpage-workflow.mjs
+++ b/scripts/validate-webpage-workflow.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const root = process.cwd();
+const failures = [];
+const contents = new Map();
+
+const requiredIncludes = {
+  "README.md": [
+    "[Webpage Generation Workflow](guides/webpage-generation-workflow.md)",
+  ],
+  "GUIDE.md": [
+    "[Webpage generation workflow](guides/webpage-generation-workflow.md)",
+    "content-to-layout match",
+    "harmony evaluation",
+    "GPT Image reference",
+    "implementation handoff",
+  ],
+  "guides/layout-brief.md": [
+    "## Webpage Generation Intake",
+    "Content-to-layout match:",
+    "Harmony evaluation:",
+    "GPT Image reference:",
+    "Required preconditions before prompt:",
+    "Image review extract-vs-ignore:",
+    "Implementation handoff:",
+    "Accepted image debt:",
+    "## Minimum Required Fields By Use Case",
+    "Homepage:",
+    "Dashboard:",
+    "Article:",
+    "Form:",
+    "Command surface:",
+    "## Rejected Alternatives",
+    "Rejected pattern or recipe:",
+    "Reason rejected:",
+  ],
+  "guides/decision-tree.md": [
+    "Rejected alternatives:",
+  ],
+  "guides/webpage-generation-workflow.md": [
+    "type: Planning Guide",
+    "# Webpage Generation Workflow",
+    "## Use Cases",
+    "## Content-to-Layout Match",
+    "## Harmony Evaluation",
+    "## GPT Image Reference",
+    "Required preconditions before prompt:",
+    "Extract from image:",
+    "Ignore from image:",
+    "## Implementation Handoff",
+    "Implementation debt:",
+    "Final implementation proof:",
+    "## Workflow Route Examples",
+    "### Homepage Route",
+    "### Dashboard Route",
+    "### Article Route",
+    "### Form Route",
+    "### Command Surface Route",
+  ],
+  "recipes/index.md": [
+    "[Homepage](homepage.md)",
+  ],
+  "recipes/homepage.md": [
+    "type: Layout Recipe",
+    "screen_type: Homepage",
+    "## Recommended Pattern Stack",
+    "## Content-To-Layout Matching",
+    "## GPT Image Reference",
+    "Required preconditions before prompt:",
+    "Image review extract-vs-ignore:",
+  ],
+  "quality/gates/index.md": [
+    "[Harmony evaluation gate](harmony-evaluation.md)",
+  ],
+  "quality/gates/harmony-evaluation.md": [
+    "type: Quality Gate",
+    "## Required Contract",
+    "Content-to-layout match:",
+    "Overall harmony:",
+    "GPT Image reference:",
+    "Implementation handoff:",
+    "Rejected alternatives:",
+    "Do not generate a GPT Image reference before harmony evaluation approves the semantic order, section jobs, pattern stack, scroll owner, and constraints.",
+    "Source order, accessibility, brand correctness, and usability cannot be inferred from the image.",
+    "Final implementation proof:",
+  ],
+};
+
+const routeSteps = [
+  "Content blocks",
+  "Section jobs",
+  "Recipe",
+  "Pattern stack",
+  "Scroll owner",
+  "Constraints",
+  "Harmony evaluation",
+  "GPT Image reference",
+  "Implementation handoff",
+];
+
+const workflowRoutes = [
+  "Homepage",
+  "Dashboard",
+  "Article",
+  "Form",
+  "Command Surface",
+];
+
+function read(relative) {
+  if (contents.has(relative)) return contents.get(relative);
+  const absolute = path.join(root, relative);
+  if (!fs.existsSync(absolute)) {
+    failures.push(`${relative}: missing file`);
+    contents.set(relative, "");
+    return "";
+  }
+  const content = fs.readFileSync(absolute, "utf8");
+  contents.set(relative, content);
+  return content;
+}
+
+for (const [relative, snippets] of Object.entries(requiredIncludes)) {
+  const content = read(relative);
+  for (const snippet of snippets) {
+    if (!content.includes(snippet)) failures.push(`${relative}: missing ${snippet}`);
+  }
+}
+
+function routeSection(content, route) {
+  const heading = `### ${route} Route`;
+  const start = content.indexOf(heading);
+  if (start === -1) return "";
+  const afterHeading = content.slice(start + heading.length);
+  const nextHeading = afterHeading.search(/\n### /);
+  return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+}
+
+function requireRouteOrder(relative, route) {
+  const content = read(relative);
+  const section = routeSection(content, route);
+  if (!section) {
+    failures.push(`${relative}: missing ### ${route} Route`);
+    return;
+  }
+
+  const harmonyIndex = section.indexOf("Harmony evaluation");
+  const imageIndex = section.indexOf("GPT Image reference");
+  if (harmonyIndex !== -1 && imageIndex !== -1 && imageIndex < harmonyIndex) {
+    failures.push(`${relative}: route ${route} places GPT Image reference before Harmony evaluation`);
+  }
+
+  let previousIndex = -1;
+  let previousStep = "";
+  for (const step of routeSteps) {
+    const index = section.indexOf(step);
+    if (index === -1) {
+      failures.push(`${relative}: route ${route} missing ${step}`);
+      continue;
+    }
+    if (index < previousIndex) {
+      failures.push(`${relative}: route ${route} places ${step} before ${previousStep}`);
+    }
+    previousIndex = index;
+    previousStep = step;
+  }
+}
+
+for (const route of workflowRoutes) {
+  requireRouteOrder("guides/webpage-generation-workflow.md", route);
+}
+
+const result = {
+  ok: failures.length === 0,
+  checkedFiles: Object.keys(requiredIncludes),
+  checkedRequirements: Object.values(requiredIncludes).reduce((total, snippets) => total + snippets.length, 0),
+  failures,
+};
+
+if (json) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (result.ok) {
+  console.log(`ok: ${result.checkedRequirements} webpage workflow requirements`);
+} else {
+  console.error(result.failures.join("\n"));
+}
+
+process.exit(result.ok ? 0 : 1);


### PR DESCRIPTION
## Summary
- add webpage generation workflow route examples for homepage, dashboard, article, form, and command surfaces
- add layout intake fields, rejected-alternative recording, homepage recipe, and harmony gate rules
- add validator coverage that rejects GPT Image references before harmony evaluation

## Verification
- node scripts/test-validate-webpage-workflow.mjs
- node scripts/validate-webpage-workflow.mjs --json
- node scripts/validate-links.mjs --json
- node scripts/validate-okf.mjs --json
- node scripts/validate-patterns.mjs --json
- node scripts/validate-catalog.mjs --json
