### PR TITLE
Add information architecture navigation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,8 @@ jobs:
           node -c scripts/test-validate-patterns.mjs
           node -c scripts/validate-links.mjs
           node -c scripts/validate-catalog.mjs
+          node -c scripts/validate-ia.mjs
+          node -c scripts/test-validate-ia.mjs
           git diff --check
 
       - name: Generated artifacts are current
@@ -47,6 +49,11 @@ jobs:
 
       - name: Markdown link check
         run: node scripts/validate-links.mjs --json
+
+      - name: Information architecture check
+        run: |
+          node scripts/validate-ia.mjs --json
+          node scripts/test-validate-ia.mjs --json
 
       - name: Pattern count and category coverage
         run: node scripts/validate-catalog.mjs --json

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -6,6 +6,8 @@ description: Generated index of layout-gallery patterns.
 
 # Layout Pattern Catalog
 
+Primary role: pattern lookup.
+
 Generated from `scripts/generate-patterns.mjs` and `scripts/pattern-data.mjs`.
 
 ## Planning Layer

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -6,6 +6,8 @@ description: Pre-design entry point for choosing and composing layout-gallery pa
 
 # Layout Planning Guide
 
+Primary role: planning workflow.
+
 Use this guide before a layout problem appears. It helps you classify a screen, name its spatial responsibilities, and choose a small stack of layout patterns before writing application CSS.
 
 `layout-gallery` has two modes:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,44 @@ description: Principles and authoring policy for the layout pattern library.
 
 `layout-gallery` is a gallery of minimal, portable CSS layout patterns.
 
+Primary role: repository guide.
+
 Each pattern documents one primary spatial problem and the smallest robust HTML/CSS structure that solves it. The gallery is not a visual design system: reusable pattern CSS should stabilize structure, flow, sizing, alignment, spacing, scrolling, ratio, and containment while leaving brand, typography, color, shadow, animation, and decoration outside the core pattern.
+
+## Repository Entry Roles
+
+Use each root hub for one primary job.
+
+| Entry | Primary role | Use when |
+| --- | --- | --- |
+| [README](README.md) | Repository guide | You need the library purpose, policies, and task routes. |
+| [OKF index](index.md) | OKF bundle map | You need a compact knowledge-bundle table of contents. |
+| [Layout Planning Guide](GUIDE.md) | Planning workflow | You need to classify a screen before choosing patterns. |
+| [Layout Pattern Catalog](CATALOG.md) | Pattern lookup | You already know the spatial problem or pattern name. |
+
+## Task Routes
+
+Each common task has one primary route. Use secondary links only after the primary route answers the first decision.
+
+| Task | Primary route | Why |
+| --- | --- | --- |
+| `plan a screen before the layout problem is obvious` | [Layout Planning Guide](GUIDE.md) | It sequences task, content, scroll, recipe, and verification choices. |
+| `choose a pattern when the name is unknown` | [Decision Tree](guides/decision-tree.md) | It routes from constraints to pattern categories. |
+| `fill in requirements before selecting a pattern stack` | [Layout Brief Template](guides/layout-brief.md) | It captures content, constraints, and verification inputs. |
+| `compose a full screen from primitives` | [Layout Recipes](recipes/index.md) | Recipes map screen models to pattern stacks. |
+| `choose a settings layout` | [SaaS Settings Recipe](recipes/saas-settings.md) | It is the primary route for stable settings navigation and constrained content. |
+| `choose a dashboard layout` | [Dashboard Recipe](recipes/dashboard.md) | It is the primary route for repeated panels and scan paths. |
+| `choose an article layout` | [Article Page Recipe](recipes/article-page.md) | It is the primary route for readable prose plus supporting material. |
+| `choose a list-detail layout` | [List Detail Recipe](recipes/list-detail.md) | It is the primary route for browse-and-inspect workflows. |
+| `look up a known layout primitive` | [Layout Pattern Catalog](CATALOG.md) | It is the generated pattern lookup surface. |
+| `browse pattern categories` | [Pattern Categories](patterns/index.md) | It groups generated patterns by spatial family. |
+| `run findability QA` | [Tree-Test Findability QA](quality/index.md#tree-test-findability-qa) | It tests whether task routes are discoverable, not just linked. |
+
+## Link Policy
+
+- Navigation links move a reader to the next decision point in the repository. Root hubs, indexes, parent links, and next-step links are navigation links.
+- Citation links identify source lineage or evidence boundaries. They support a claim but should not be the only way to continue a task.
+- Dependency links identify generated, validation, or composition relationships. They explain what must stay in sync, such as `scripts/pattern-data.mjs`, generated pattern files, catalog entries, and validator fixtures.
 
 ## How To Use This Repository
 
@@ -17,6 +54,7 @@ Each pattern documents one primary spatial problem and the smallest robust HTML/
 - Fill out the [Layout Brief Template](guides/layout-brief.md) before choosing a pattern stack.
 - Use [Layout Recipes](recipes/index.md) when you need screen-level composition.
 - Use [Layout Pattern Catalog](CATALOG.md) when you already know the spatial problem.
+- Use [Quality And Findability](quality/index.md) when checking repository routes and leaf navigation.
 
 ## Principles
 

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ okf_version: "0.1"
 
 `layout-gallery` is an OKF-style knowledge bundle of minimal, portable CSS layout patterns.
 
+Primary role: OKF bundle map.
+
 ## Concepts
 
 - [Repository principles](README.md) - Principles and authoring policy for the layout pattern library.
@@ -16,4 +18,5 @@ okf_version: "0.1"
 - [Agent instructions](AGENTS.md) - Rules coding agents must follow when editing this layout pattern library.
 - [Layout pattern catalog](CATALOG.md) - Generated index of layout-gallery patterns.
 - [Pattern categories](patterns/index.md) - Category index for generated layout patterns.
+- [Quality and findability](quality/index.md) - IA route checks and tree-test QA for repository navigation.
 - [Update log](log.md) - Bundle update history.

--- a/patterns/centering/center.md
+++ b/patterns/centering/center.md
@@ -72,3 +72,8 @@ Use `center` as the stable pattern root and compose additional layout behavior o
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Centering patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/centering/super-center.md
+++ b/patterns/centering/super-center.md
@@ -74,3 +74,8 @@ Use `super_center` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Centering patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/containment/box.md
+++ b/patterns/containment/box.md
@@ -72,3 +72,8 @@ Use `box` as the stable pattern root and compose additional layout behavior outs
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Containment patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/containment/clamped-card.md
+++ b/patterns/containment/clamped-card.md
@@ -71,3 +71,8 @@ Use `clamped_card` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Containment patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/containment/content-limiter.md
+++ b/patterns/containment/content-limiter.md
@@ -72,3 +72,8 @@ Use `content_limiter` as the stable pattern root and compose additional layout b
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Containment patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/containment/fluid-styles.md
+++ b/patterns/containment/fluid-styles.md
@@ -71,3 +71,8 @@ Use `fluid_styles` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Containment patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/card-grid.md
+++ b/patterns/grid-repetition/card-grid.md
@@ -73,3 +73,8 @@ Use `card_grid` as the stable pattern root and compose additional layout behavio
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/columns.md
+++ b/patterns/grid-repetition/columns.md
@@ -72,3 +72,8 @@ Use `columns` as the stable pattern root and compose additional layout behavior 
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/dense-grid.md
+++ b/patterns/grid-repetition/dense-grid.md
@@ -73,3 +73,8 @@ Use `dense_grid` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/grid-wrapper.md
+++ b/patterns/grid-repetition/grid-wrapper.md
@@ -74,3 +74,8 @@ Use `grid_wrapper` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/masonry-approx.md
+++ b/patterns/grid-repetition/masonry-approx.md
@@ -72,3 +72,8 @@ Use `masonry_approx` as the stable pattern root and compose additional layout be
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/page-grid.md
+++ b/patterns/grid-repetition/page-grid.md
@@ -75,3 +75,8 @@ Use `page_grid` as the stable pattern root and compose additional layout behavio
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/ram-grid.md
+++ b/patterns/grid-repetition/ram-grid.md
@@ -73,3 +73,8 @@ Use `ram_grid` as the stable pattern root and compose additional layout behavior
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/grid-repetition/twelve-span-grid.md
+++ b/patterns/grid-repetition/twelve-span-grid.md
@@ -77,3 +77,8 @@ Use `twelve_span_grid` as the stable pattern root and compose additional layout 
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Grid / Repetition patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/badge-list.md
+++ b/patterns/in-line-grouping/badge-list.md
@@ -79,3 +79,8 @@ Use `badge_list` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/breadcrumb.md
+++ b/patterns/in-line-grouping/breadcrumb.md
@@ -74,3 +74,8 @@ Use `breadcrumb` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/cluster.md
+++ b/patterns/in-line-grouping/cluster.md
@@ -74,3 +74,8 @@ Use `cluster` as the stable pattern root and compose additional layout behavior 
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/deconstructed-pancake.md
+++ b/patterns/in-line-grouping/deconstructed-pancake.md
@@ -77,3 +77,8 @@ Use `deconstructed_pancake` as the stable pattern root and compose additional la
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/pagination.md
+++ b/patterns/in-line-grouping/pagination.md
@@ -74,3 +74,8 @@ Use `pagination` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/reel.md
+++ b/patterns/in-line-grouping/reel.md
@@ -75,3 +75,8 @@ Use `reel` as the stable pattern root and compose additional layout behavior out
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/split-nav.md
+++ b/patterns/in-line-grouping/split-nav.md
@@ -82,3 +82,8 @@ Use `split_nav` as the stable pattern root and compose additional layout behavio
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/tab-strip.md
+++ b/patterns/in-line-grouping/tab-strip.md
@@ -73,3 +73,8 @@ Use `tab_strip` as the stable pattern root and compose additional layout behavio
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/in-line-grouping/wrap-row.md
+++ b/patterns/in-line-grouping/wrap-row.md
@@ -74,3 +74,8 @@ Use `wrap_row` as the stable pattern root and compose additional layout behavior
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [In-line grouping patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/media-fit/frame.md
+++ b/patterns/media-fit/frame.md
@@ -80,3 +80,8 @@ Use `frame` as the stable pattern root and compose additional layout behavior ou
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Media / Fit patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/media-fit/icon-frame.md
+++ b/patterns/media-fit/icon-frame.md
@@ -72,3 +72,8 @@ Use `icon_frame` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Media / Fit patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/overlay-exception/imposter.md
+++ b/patterns/overlay-exception/imposter.md
@@ -80,3 +80,8 @@ Use `imposter` as the stable pattern root and compose additional layout behavior
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Overlay / Exception patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/overlay-exception/overlay-stack.md
+++ b/patterns/overlay-exception/overlay-stack.md
@@ -74,3 +74,8 @@ Use `overlay_stack` as the stable pattern root and compose additional layout beh
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Overlay / Exception patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/list-detail.md
+++ b/patterns/split-sidebar/list-detail.md
@@ -80,3 +80,8 @@ Use `list_detail` as the stable pattern root and compose additional layout behav
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/main-with-rail.md
+++ b/patterns/split-sidebar/main-with-rail.md
@@ -80,3 +80,8 @@ Use `main_with_rail` as the stable pattern root and compose additional layout be
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/media-object.md
+++ b/patterns/split-sidebar/media-object.md
@@ -87,3 +87,8 @@ Use `media_object` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/sidebar.md
+++ b/patterns/split-sidebar/sidebar.md
@@ -86,3 +86,8 @@ Use `sidebar` as the stable pattern root and compose additional layout behavior 
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/split-screen.md
+++ b/patterns/split-sidebar/split-screen.md
@@ -77,3 +77,8 @@ Use `split_screen` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/sticky-aside.md
+++ b/patterns/split-sidebar/sticky-aside.md
@@ -82,3 +82,8 @@ Use `sticky_aside` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/supporting-pane.md
+++ b/patterns/split-sidebar/supporting-pane.md
@@ -80,3 +80,8 @@ Use `supporting_pane` as the stable pattern root and compose additional layout b
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/split-sidebar/switcher.md
+++ b/patterns/split-sidebar/switcher.md
@@ -78,3 +78,8 @@ Use `switcher` as the stable pattern root and compose additional layout behavior
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Split / Sidebar patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/stacking/feed.md
+++ b/patterns/stacking/feed.md
@@ -73,3 +73,8 @@ Use `feed` as the stable pattern root and compose additional layout behavior out
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Stacking patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/stacking/line-up.md
+++ b/patterns/stacking/line-up.md
@@ -80,3 +80,8 @@ Use `line_up` as the stable pattern root and compose additional layout behavior 
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Stacking patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/stacking/stack.md
+++ b/patterns/stacking/stack.md
@@ -72,3 +72,8 @@ Use `stack` as the stable pattern root and compose additional layout behavior ou
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Stacking patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/stacking/step-nav.md
+++ b/patterns/stacking/step-nav.md
@@ -73,3 +73,8 @@ Use `step_nav` as the stable pattern root and compose additional layout behavior
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Stacking patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/cover.md
+++ b/patterns/viewport-shell/cover.md
@@ -75,3 +75,8 @@ Use `cover` as the stable pattern root and compose additional layout behavior ou
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/fixed-sidenav-shell.md
+++ b/patterns/viewport-shell/fixed-sidenav-shell.md
@@ -82,3 +82,8 @@ Use `fixed_sidenav_shell` as the stable pattern root and compose additional layo
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/holy-grail.md
+++ b/patterns/viewport-shell/holy-grail.md
@@ -97,3 +97,8 @@ Use `holy_grail` as the stable pattern root and compose additional layout behavi
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/panel-layout.md
+++ b/patterns/viewport-shell/panel-layout.md
@@ -80,3 +80,8 @@ Use `panel_layout` as the stable pattern root and compose additional layout beha
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/scroll-body-shell.md
+++ b/patterns/viewport-shell/scroll-body-shell.md
@@ -78,3 +78,8 @@ Use `scroll_body_shell` as the stable pattern root and compose additional layout
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/sticky-footer.md
+++ b/patterns/viewport-shell/sticky-footer.md
@@ -77,3 +77,8 @@ Use `sticky_footer` as the stable pattern root and compose additional layout beh
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/patterns/viewport-shell/sticky-header.md
+++ b/patterns/viewport-shell/sticky-header.md
@@ -71,3 +71,8 @@ Use `sticky_header` as the stable pattern root and compose additional layout beh
 
 - Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.
 - Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.
+
+## IA Navigation
+
+Parent: [Viewport / Shell patterns](index.md) in [Pattern Categories](../index.md).
+Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.

--- a/quality/index.md
+++ b/quality/index.md
@@ -1,0 +1,26 @@
+# Quality And Findability
+
+`quality/` records IA checks that help readers choose the right route through `layout-gallery`.
+
+## Concepts
+
+- [Repository guide](../README.md) - Root hub roles, task routes, and link policy.
+- [Pattern categories](../patterns/index.md) - Parent context for generated pattern leaves.
+- [Layout recipes](../recipes/index.md) - Parent context for screen-level recipe leaves.
+
+## Tree-Test Findability QA
+
+Findability QA checks whether a reader can choose the correct route for a task without already knowing the repository structure.
+
+Use this script for lightweight tree tests:
+
+| Scenario | Start | Expected primary route | PASS condition |
+| --- | --- | --- | --- |
+| Choose a layout for a screen with unknown constraints. | [README](../README.md) | [Layout Planning Guide](../GUIDE.md) | The reader starts with planning instead of a primitive. |
+| Find a primitive for a known spatial problem. | [README](../README.md) | [Layout Pattern Catalog](../CATALOG.md) | The reader reaches the generated catalog. |
+| Browse all spatial families. | [OKF index](../index.md) | [Pattern Categories](../patterns/index.md) | The reader reaches category-level browsing. |
+| Compose a screen-level layout. | [README](../README.md) | [Layout Recipes](../recipes/index.md) | The reader reaches recipes before individual pattern leaves. |
+| Choose a settings layout. | [README](../README.md) | [SaaS Settings Recipe](../recipes/saas-settings.md) | The reader reaches the settings recipe before catalog browsing. |
+| Run findability QA. | [README](../README.md) | [Quality And Findability](index.md) | The reader reaches this QA script. |
+
+Record `PASS` only when the expected primary route is the first route selected. A link resolving successfully is not enough; the selected route must match the task intent.

--- a/recipes/article-page.md
+++ b/recipes/article-page.md
@@ -39,3 +39,8 @@ Do not use sticky aside behavior when supplemental content must be read in seque
 
 - [sidebar](../patterns/split-sidebar/sidebar.md)
 - [box](../patterns/containment/box.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/command-surface.md
+++ b/recipes/command-surface.md
@@ -39,3 +39,8 @@ Do not use this recipe for a simple content page with one or two actions. A [clu
 
 - [reel](../patterns/in-line-grouping/reel.md)
 - [panel-layout](../patterns/viewport-shell/panel-layout.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/dashboard.md
+++ b/recipes/dashboard.md
@@ -40,3 +40,8 @@ Do not use this recipe for a single focused workflow. A [form flow](form-flow.md
 - [ram-grid](../patterns/grid-repetition/ram-grid.md)
 - [dense-grid](../patterns/grid-repetition/dense-grid.md)
 - [wrap-row](../patterns/in-line-grouping/wrap-row.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/form-flow.md
+++ b/recipes/form-flow.md
@@ -39,3 +39,8 @@ Do not use this recipe for a data-dense editor where users compare many fields a
 
 - [sticky-footer](../patterns/viewport-shell/sticky-footer.md)
 - [line-up](../patterns/stacking/line-up.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/list-detail.md
+++ b/recipes/list-detail.md
@@ -39,3 +39,8 @@ Do not use this recipe when the detail page is a full navigation destination. Us
 
 - [supporting-pane](../patterns/split-sidebar/supporting-pane.md)
 - [fixed-sidenav-shell](../patterns/viewport-shell/fixed-sidenav-shell.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/recipes/saas-settings.md
+++ b/recipes/saas-settings.md
@@ -39,3 +39,8 @@ Do not use this recipe for a short one-page preference form where document flow 
 
 - [scroll-body-shell](../patterns/viewport-shell/scroll-body-shell.md)
 - [supporting-pane](../patterns/split-sidebar/supporting-pane.md)
+
+## IA Navigation
+
+Parent: [Layout Recipes](index.md).
+Next: [Quality And Findability](../quality/index.md) for route checks, or [Layout Pattern Catalog](../CATALOG.md) when replacing a primitive.

--- a/scripts/generate-patterns.mjs
+++ b/scripts/generate-patterns.mjs
@@ -77,6 +77,11 @@ function contractSections(pattern, rootClass) {
     "- Do not add color, border, shadow, typography, or animation rules to reusable pattern CSS.",
     "- Do not use this pattern to repair unclear HTML structure; make the DOM roles legible first.",
     "",
+    "## IA Navigation",
+    "",
+    `Parent: [${pattern.category} patterns](index.md) in [Pattern Categories](../index.md).`,
+    "Next: [Layout Recipes](../../recipes/index.md) for screen-level composition, or return to the [Layout Pattern Catalog](../../CATALOG.md) when choosing another primitive.",
+    "",
   ];
 }
 
@@ -166,6 +171,8 @@ fs.writeFileSync(
     "---",
     "",
     "# Layout Pattern Catalog",
+    "",
+    "Primary role: pattern lookup.",
     "",
     "Generated from `scripts/generate-patterns.mjs` and `scripts/pattern-data.mjs`.",
     "",

--- a/scripts/test-validate-ia.mjs
+++ b/scripts/test-validate-ia.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const validator = path.join(root, "scripts", "validate-ia.mjs");
+
+const baseFiles = {
+  "README.md": [
+    "# layout-gallery",
+    "",
+    "Primary role: repository guide.",
+    "",
+    "## Repository Entry Roles",
+    "",
+    "| Entry | Primary role |",
+    "| --- | --- |",
+    "| [README](README.md) | Repository guide |",
+    "",
+    "## Task Routes",
+    "",
+    "| Task | Primary route |",
+    "| --- | --- |",
+    "| `plan a layout` | [Guide](GUIDE.md) |",
+    "| `choose a primitive` | [Catalog](CATALOG.md) |",
+    "| `review quality` | [Quality](quality/index.md) |",
+    "| `check links` | [Quality](quality/index.md) |",
+    "| `write a recipe` | [Recipes](recipes/index.md) |",
+    "| `inspect pattern categories` | [Patterns](patterns/index.md) |",
+    "| `fill a brief` | [Brief](guides/layout-brief.md) |",
+    "| `record evidence` | [Quality](quality/index.md) |",
+    "| `run findability QA` | [Findability](quality/index.md) |",
+    "| `choose settings` | [Settings](recipes/saas-settings.md) |",
+    "",
+    "## Link Policy",
+    "",
+    "- Navigation links move a reader to the next decision point.",
+    "- Citation links identify source lineage or evidence boundaries.",
+    "- Dependency links identify generated, validation, or composition relationships.",
+    "",
+  ].join("\n"),
+  "index.md": "# Bundle\n\nPrimary role: OKF bundle map.\n",
+  "GUIDE.md": "# Guide\n\nPrimary role: planning workflow.\n",
+  "CATALOG.md": "# Catalog\n\nPrimary role: pattern lookup.\n",
+  "patterns/index.md": "# Patterns\n",
+  "patterns/stacking/index.md": "# Stacking\n",
+  "patterns/stacking/stack.md": leaf("Stack", "index.md", "../../recipes/index.md"),
+  "recipes/index.md": "# Recipes\n",
+  "recipes/saas-settings.md": leaf("SaaS Settings", "index.md", "../quality/index.md"),
+  "quality/index.md": "# Quality\n\n## Tree-Test Findability QA\n\n- [Repository guide](../README.md)\n",
+};
+
+const cases = [
+  {
+    name: "missing_leaf_parent",
+    mutate: {
+      "patterns/stacking/stack.md": "# Stack\n\nNext: [Recipes](../../recipes/index.md)\n",
+    },
+    expect: "patterns/stacking/stack.md: missing Parent navigation link",
+  },
+  {
+    name: "missing_leaf_next",
+    mutate: {
+      "patterns/stacking/stack.md": "# Stack\n\nParent: [Stacking](index.md)\n",
+    },
+    expect: "patterns/stacking/stack.md: missing Next navigation link",
+  },
+  {
+    name: "missing_task_routes",
+    mutate: {
+      "README.md": "# layout-gallery\n\nPrimary role: repository guide.\n\n## Repository Entry Roles\n",
+    },
+    expect: "README.md: missing ## Task Routes",
+  },
+  {
+    name: "missing_link_policy",
+    mutate: {
+      "README.md": baseFiles["README.md"].replace(/\n## Link Policy\n[\s\S]*$/, "\n"),
+    },
+    expect: "README.md: missing ## Link Policy",
+  },
+  {
+    name: "success_path",
+    expect: null,
+  },
+];
+
+function leaf(title, parent, next) {
+  return `# ${title}\n\n## IA Navigation\n\nParent: [Parent](${parent}).\nNext: [Next](${next}).\n`;
+}
+
+function writeFixture(testCase) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `layout-gallery-ia-${testCase.name}-`));
+  const entries = { ...baseFiles, ...(testCase.mutate ?? {}) };
+  for (const [relative, content] of Object.entries(entries)) {
+    const target = path.join(dir, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return dir;
+}
+
+function runCase(testCase) {
+  const dir = writeFixture(testCase);
+  const result = spawnSync(process.execPath, [validator, "--json"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  fs.rmSync(dir, { force: true, recursive: true });
+  const output = JSON.parse(result.stdout);
+  const passed = testCase.expect ? !output.ok && output.failures.includes(testCase.expect) : output.ok;
+  return {
+    name: testCase.name,
+    ok: passed,
+    expected: testCase.expect ?? "ok:true",
+    actual: output,
+  };
+}
+
+const results = cases.map(runCase);
+const report = {
+  ok: results.every((result) => result.ok),
+  results,
+};
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(report.ok ? 0 : 1);

--- a/scripts/validate-ia.mjs
+++ b/scripts/validate-ia.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const json = args.has("--json");
+const root = process.cwd();
+const failures = [];
+
+const rootRoles = [
+  ["README.md", "Primary role: repository guide"],
+  ["index.md", "Primary role: OKF bundle map"],
+  ["GUIDE.md", "Primary role: planning workflow"],
+  ["CATALOG.md", "Primary role: pattern lookup"],
+];
+
+function read(relative) {
+  const target = path.join(root, relative);
+  if (!fs.existsSync(target)) {
+    failures.push(`${relative}: missing file`);
+    return "";
+  }
+  return fs.readFileSync(target, "utf8");
+}
+
+function stripFencedCodeBlocks(content) {
+  return content.replace(/```[\s\S]*?```/g, "");
+}
+
+function walk(dir) {
+  const absolute = path.join(root, dir);
+  if (!fs.existsSync(absolute)) return [];
+  return fs.readdirSync(absolute, { withFileTypes: true }).flatMap((entry) => {
+    const next = path.join(absolute, entry.name);
+    if (entry.isDirectory()) return walk(path.relative(root, next));
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "index.md") return [];
+    return [path.relative(root, next)];
+  });
+}
+
+function requireIncludes(relative, text) {
+  if (!read(relative).includes(text)) failures.push(`${relative}: missing ${text}`);
+}
+
+function requireRootRoles() {
+  for (const [relative, role] of rootRoles) {
+    requireIncludes(relative, role);
+  }
+  requireIncludes("README.md", "## Repository Entry Roles");
+  requireIncludes("README.md", "## Task Routes");
+  requireIncludes("README.md", "## Link Policy");
+  requireIncludes("README.md", "Navigation links");
+  requireIncludes("README.md", "Citation links");
+  requireIncludes("README.md", "Dependency links");
+  requireIncludes("quality/index.md", "## Tree-Test Findability QA");
+}
+
+function requireTaskRoutes() {
+  const content = read("README.md");
+  const section = content.split("## Task Routes")[1]?.split("\n## ")[0] ?? "";
+  const routeRows = section.split("\n").filter((line) => /^\| `[^`]+` \| \[[^\]]+\]\([^)]+\) \|/.test(line));
+  if (routeRows.length < 10) failures.push(`README.md: expected at least 10 task route rows, found ${routeRows.length}`);
+}
+
+function requireLeafNavigation() {
+  for (const file of ["patterns", "recipes", "quality"].flatMap(walk)) {
+    const content = stripFencedCodeBlocks(read(file));
+    if (!/^Parent: \[[^\]]+\]\([^)]+\)/m.test(content)) failures.push(`${file}: missing Parent navigation link`);
+    if (!/^Next: \[[^\]]+\]\([^)]+\)/m.test(content)) failures.push(`${file}: missing Next navigation link`);
+  }
+}
+
+requireRootRoles();
+requireTaskRoutes();
+requireLeafNavigation();
+
+const result = {
+  checkedLeafFiles: ["patterns", "recipes", "quality"].flatMap(walk).length,
+  failures,
+  ok: failures.length === 0,
+};
+
+if (json) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (result.ok) {
+  console.log(`ok: ${result.checkedLeafFiles} IA leaf files`);
+} else {
+  console.error(result.failures.join("\n"));
+}
+
+process.exit(result.ok ? 0 : 1);


### PR DESCRIPTION
## Summary

- defines distinct root hub roles, task routes, and link policy for repository navigation
- adds Parent/Next IA navigation to generated pattern leaves and recipe leaves
- adds `quality/index.md` tree-test findability QA plus `validate-ia` CI coverage

## Verification

- `node -c scripts/generate-patterns.mjs scripts/pattern-data.mjs scripts/validate-okf.mjs scripts/test-validate-okf.mjs scripts/validate-patterns.mjs scripts/test-validate-patterns.mjs scripts/validate-links.mjs scripts/validate-catalog.mjs scripts/validate-ia.mjs scripts/test-validate-ia.mjs`
- `node scripts/generate-patterns.mjs && git diff --exit-code`
- `node scripts/validate-okf.mjs --json`
- `node scripts/test-validate-okf.mjs --json`
- `node scripts/validate-patterns.mjs --min-count 30 --json`
- `node scripts/test-validate-patterns.mjs --json`
- `node scripts/validate-links.mjs --json`
- `node scripts/validate-catalog.mjs --json`
- `node scripts/validate-ia.mjs --json`
- `node scripts/test-validate-ia.mjs --json`
- `git diff --check`

Evidence: `/var/folders/p6/2s6_p7017f1bd4sdm4x_7r700000gn/T/axis01-atomic-postcommit.XXXXXX.txt.gt1AtU6Cul`
