### PR TITLE
Add structured quality claim records

### DIFF
--- a/quality/claim-records/index.md
+++ b/quality/claim-records/index.md
@@ -1,0 +1,3 @@
+# Claim Records
+
+- [Sample claim records](samples.md)

--- a/quality/claim-records/samples.md
+++ b/quality/claim-records/samples.md
@@ -1,0 +1,81 @@
+---
+type: Quality Reference
+title: Sample Claim Records
+description: Filled structured quality claims for common review decisions.
+---
+
+# Sample Claim Records
+
+These examples show the minimum useful record shape. They are intentionally compact so high-impact claims remain reviewable without becoming heavy documentation work.
+
+## Claim Record 1 - Harmony Before Image Generation
+
+Principle: Accessibility precedence and principles before evidence.
+
+Claim: A homepage GPT Image reference should be generated only after the content-to-layout match and harmony evaluation approve semantic order, section jobs, pattern stack, scroll owner, and constraints.
+
+Context: Webpage generation can otherwise let a visual reference decide layout before source order and task flow are known.
+
+Use case: Homepage or ordinary webpage generation from raw content.
+
+Warrant: The image can help inspect hierarchy and spacing only after the layout contract names the content jobs and constraints it should express.
+
+Evidence family: `rationale`, `source`, `screenshot`.
+
+Verification protocol: Check that the layout brief names use case, section jobs, pattern stack, rejected alternatives, harmony notes, GPT Image reference prompt, and implementation handoff before image generation.
+
+Implementation handoff: Build semantic HTML and layout patterns first; copy only hierarchy, rhythm, media treatment, and CTA priority into product-level styling after the gate passes.
+
+Boundary or limitation: The image cannot prove usability, accessibility, brand fit, or final implementation quality.
+
+Debt or escalation: If the visual reference conflicts with source order, focus order, accessibility, or content stress behavior, regenerate the prompt or record a blocked decision.
+
+Decision: pass when the harmony gate is complete before the image is generated.
+
+## Claim Record 2 - Screenshot Diff Limits
+
+Principle: Visual QA evidence precedes visual judgment.
+
+Claim: A stable screenshot diff supports a rendered-state claim, but it does not prove usability or accessibility.
+
+Context: Visual review often finds regressions, overflow, hidden text, and hierarchy shifts, but user-facing outcomes require stronger evidence.
+
+Use case: not applicable.
+
+Warrant: Screenshots show a bounded rendered state; usability and accessibility depend on task completion, semantics, keyboard flow, assistive technology, and user context.
+
+Evidence family: `screenshot`, `accessibility`, `user`.
+
+Verification protocol: Pair screenshots with the visual-evidence gate and route accessibility or usability claims to their dedicated evidence families.
+
+Implementation handoff: not applicable.
+
+Boundary or limitation: A screenshot can hide focus order, screen-reader output, dynamic states, and untested content stress.
+
+Debt or escalation: Escalate to accessibility or user evidence when the claim says readable, usable, accessible, clear, good, better, or harmonious for a person or task.
+
+Decision: review_required when screenshots are the only evidence for a human-outcome claim.
+
+## Claim Record 3 - Accessibility Scan Limits
+
+Principle: Accessibility is a boundary condition.
+
+Claim: An automated accessibility scan can support a scoped accessibility finding, but it cannot certify complete accessibility.
+
+Context: Automated checks miss keyboard behavior, assistive-technology behavior, cognitive load, language clarity, and some semantic defects.
+
+Use case: not applicable.
+
+Warrant: The scan is validator evidence for detectable rules; complete accessibility needs manual and contextual evidence.
+
+Evidence family: `validator`, `accessibility`, `user`.
+
+Verification protocol: Record the scan tool, ruleset, viewport or state, manual keyboard checks, and any required screen-reader, accessibility-tree, or cognitive review.
+
+Implementation handoff: not applicable.
+
+Boundary or limitation: The scan cannot prove accessibility for every user, device, browser, or assistive-technology pairing.
+
+Debt or escalation: Accessibility debt must name affected users, owner, review trigger, and the evidence gap before it can be accepted.
+
+Decision: blocked when a known accessibility failure is treated as a taste tradeoff or ordinary visual debt.

--- a/quality/claims.md
+++ b/quality/claims.md
@@ -1,0 +1,70 @@
+---
+type: Quality Reference
+title: Structured Quality Claims
+description: Claim-record template and scope rules for high-impact design judgments.
+---
+
+# Structured Quality Claims
+
+Use a claim record when a design judgment would otherwise rest on taste, authority, or an unlabeled artifact.
+
+The record makes the review chain inspectable:
+
+```txt
+principle -> claim -> context -> warrant -> evidence family -> verification protocol -> boundary/debt
+```
+
+## High-Impact Claim
+
+A high-impact claim is any statement that can block, approve, or redirect layout, accessibility, implementation, or design-review work.
+
+Treat the following as high-impact terms when they decide work rather than describe prose:
+
+- `good`, `better`, or `best`;
+- `harmonious` or `harmony`;
+- `appropriate`, `proper`, or `fit`;
+- `usable`, `accessible`, `readable`, `credible`, or `clear`;
+- claims that a screenshot, source, generated image, validator, or public design system proves quality.
+
+## When A Claim Record Is Required
+
+Create a claim record when:
+
+- a quality gate accepts, rejects, blocks, or defers a claim;
+- a harmony evaluation decides whether a GPT Image reference can guide implementation;
+- a screenshot, validator, accessibility scan, source, or rationale artifact is used as evidence;
+- a high-impact term changes the pattern stack, source order, accessibility requirement, implementation handoff, or accepted debt;
+- a claim names user perception, usability, accessibility, or visual quality.
+
+## Low-Risk Prose
+
+Do not require a claim record for:
+
+- navigation text, index summaries, or cross-reference copy;
+- examples that do not approve or block work;
+- local descriptions of fields already governed by a linked gate;
+- editorial wording that does not create implementation guidance.
+
+Low-risk prose can still link to a gate or claim record when the reader needs the review boundary.
+
+## Claim Record Template
+
+```txt
+Principle:
+Claim:
+Context:
+Use case:
+Warrant:
+Evidence family:
+Verification protocol:
+Implementation handoff:
+Boundary or limitation:
+Debt or escalation:
+Decision:
+```
+
+`Use case` and `Implementation handoff` are required for harmony claims. For other claim types, write `not applicable` rather than deleting the fields.
+
+## Review Rule
+
+A record is complete only when the evidence family names what the artifact can support and the boundary says what it cannot prove. Evidence without a warrant remains a blocking condition.

--- a/quality/evidence/families.md
+++ b/quality/evidence/families.md
@@ -1,0 +1,51 @@
+---
+type: Evidence Reference
+title: Evidence Family Glossary
+description: Normalized evidence families for structured quality claims.
+---
+
+# Evidence Family Glossary
+
+Use these evidence-family names in claim records. A claim can cite more than one family when the warrant needs multiple kinds of support.
+
+## `validator`
+
+Executable checks, fixtures, schema validation, link checks, and CI output.
+
+- Can support: file shape, required fields, link integrity, route order, repeatable mechanical constraints.
+- Cannot prove: usability, accessibility, visual quality, brand fit, or user comprehension.
+
+## `screenshot`
+
+Screenshots, visual diffs, viewport captures, state captures, and rendered DOM artifacts.
+
+- Can support: what rendered at a specific viewport, state, density, or interaction point.
+- Cannot prove: task success, accessibility, user preference, or complete responsive behavior by itself.
+
+## `accessibility`
+
+Automated scans, keyboard checks, contrast checks, semantic review, screen-reader or accessibility-tree review, reduced-motion checks, and cognitive accessibility review.
+
+- Can support: named accessibility risks, pass/fail observations, and review scope.
+- Cannot prove: complete accessibility for every user or every assistive-technology pairing.
+
+## `user`
+
+Participant evidence, task review, persona review, cognitive walkthrough, heuristic evaluation, or validated perception instruments.
+
+- Can support: task success, perceived clarity, user comprehension, or human-judgment claims inside the observed population and method.
+- Cannot prove: universal preference, brand quality, or outcomes outside the tested task.
+
+## `source`
+
+Academic, standards, official tooling, methodology, vendor, practice, or public design-system references.
+
+- Can support: vocabulary, methods, constraints, standards, and implementation examples.
+- Cannot prove: local quality unless connected to repository context, rendered evidence, and a warrant.
+
+## `rationale`
+
+ADR-style or Toulmin-style records, options considered, criteria, counterclaims, limitations, debt, owner, and review trigger.
+
+- Can support: why a decision is admissible, what alternatives were rejected, and what boundary controls the claim.
+- Cannot prove: the selected option is empirically best without `user` or other outcome evidence.

--- a/quality/evidence/index.md
+++ b/quality/evidence/index.md
@@ -1,0 +1,7 @@
+# Evidence References
+
+Evidence references describe what sources and artifacts can support. They do not decide quality by themselves.
+
+## References
+
+- [Evidence family glossary](families.md) - Normalized `validator`, `screenshot`, `accessibility`, `user`, `source`, and `rationale` families for claim records.

--- a/quality/gates/design-claim.md
+++ b/quality/gates/design-claim.md
@@ -1,0 +1,51 @@
+---
+type: Quality Gate
+title: Design Claim Gate
+description: Contract for admitting non-layout design claims.
+---
+
+# Design Claim Gate
+
+The design claim gate prevents evidence from becoming unsupported authority.
+
+## Required Contract
+
+Every non-layout design claim should state:
+
+```txt
+Principle:
+Claim:
+Context:
+Warrant:
+Evidence family:
+Verification protocol:
+Boundary or limitation:
+Debt or escalation:
+Decision:
+```
+
+## Evidence Families
+
+Use the normalized [evidence family glossary](../evidence/families.md):
+
+- `validator`: file shape, headings, frontmatter, source lineage, token structure, fixture output, and CI checks.
+- `screenshot`: screenshots, visual diffs, state captures, viewport captures, and rendered DOM artifacts.
+- `accessibility`: WCAG/ACT checks, keyboard checks, contrast checks, assistive-technology/manual review, and cognitive accessibility review.
+- `user`: heuristic evaluation, cognitive walkthrough, persona or task review, user testing, validated visual-aesthetics instruments, and participant evidence.
+- `source`: academic, standards, official tooling, methodology, vendor, practice, and public design-system references inside a stated boundary.
+- `rationale`: Toulmin/ADR-style records, options considered, criteria, counterclaims, limitations, debt, owner, and review trigger.
+
+## Blocking Conditions
+
+Block a design claim when:
+
+- it has evidence but no warrant;
+- it treats a screenshot diff as proof of usability;
+- it treats an automated accessibility scan as proof of accessibility;
+- it cites public design systems as proof of universal quality;
+- it conflicts with accessibility or task completion;
+- it requires changes inside generated layout pattern surfaces.
+
+## Boundary
+
+This gate admits claims. It does not prescribe a product brand, palette, illustration style, typeface, animation system, or component library.

--- a/quality/gates/harmony-evaluation.md
+++ b/quality/gates/harmony-evaluation.md
@@ -1,0 +1,57 @@
+---
+type: Quality Gate
+title: Harmony Evaluation Gate
+description: Contract for judging webpage content-to-layout fit, visual-reference use, and implementation handoff.
+---
+
+# Harmony Evaluation Gate
+
+Use this gate before a generated image or visual reference becomes implementation guidance for a homepage or ordinary webpage.
+
+## Required Contract
+
+Record:
+
+```txt
+Use case:
+Primary task:
+Audience:
+Content-to-layout match:
+Overall harmony:
+Claim record route:
+GPT Image reference:
+Implementation handoff:
+Evidence family:
+Verification protocol:
+Boundary or limitation:
+Decision:
+```
+
+## Evidence Families
+
+Use the normalized [evidence family glossary](../evidence/families.md):
+
+- `validator`: layout brief fields, recipe choice, pattern stack, semantic skeleton, linkable workflow docs, and validator output.
+- `screenshot`: generated GPT Image reference, screenshots, state captures, viewport captures, and visual diffs.
+- `accessibility`: keyboard order, focus visibility, contrast, reduced-motion, semantic landmarks, assistive-technology review, and cognitive accessibility review.
+- `user`: content hierarchy review, cognitive walkthrough, visitor decision-path review, design critique, participant testing, or validated measurement.
+- `source`: external methodology or standards used to frame the harmony claim.
+- `rationale`: claim record, rejected alternatives, limitations, accepted debt, owner, and review trigger.
+
+## Blocking Conditions
+
+Block the harmony claim when:
+
+- the use case is unnamed;
+- the page uses a fashionable layout that does not match the content jobs;
+- the GPT Image reference is generated before semantic order, section jobs, pattern stack, scroll owner, and constraints are approved;
+- a generated image is treated as proof of usability, accessibility, or brand fit;
+- visual novelty weakens source order, focus order, task completion, or content stress behavior;
+- decorative styling is moved into reusable pattern CSS;
+- the implementation handoff omits constraints, scroll ownership, accepted debt, or verification.
+
+## Boundary
+
+This gate decides whether a webpage composition is coherent enough to guide implementation. It does not define the consuming product's brand, typography, color, illustration style, animation system, or component library.
+
+Use a [structured claim record](../claims.md) when the harmony decision approves, blocks, or redirects implementation. Harmony records must include the use case and implementation handoff because they decide what the implementer may safely carry from a visual reference into product-level styling.

--- a/quality/gates/index.md
+++ b/quality/gates/index.md
@@ -1,0 +1,9 @@
+# Gate Contracts
+
+Gate contracts define what kind of evidence can support a claim.
+
+## Gates
+
+- [Design claim gate](design-claim.md) - Required shape for non-layout design claims.
+- [Rationale gate](rationale.md) - Decision rationale, alternatives, warrants, and debt.
+- [Harmony evaluation gate](harmony-evaluation.md) - Contract for judging content-to-layout fit, overall harmony, GPT Image references, and implementation handoff.

--- a/quality/gates/rationale.md
+++ b/quality/gates/rationale.md
@@ -1,0 +1,48 @@
+---
+type: Quality Gate
+title: Rationale Gate
+description: Decision-rationale contract for quality gate judgments.
+---
+
+# Rationale Gate
+
+The rationale gate records why a claim is accepted, rejected, blocked, or deferred.
+
+## Required Rationale
+
+Record:
+
+- the question being decided;
+- considered options;
+- criteria used to compare options;
+- selected option;
+- warrant connecting evidence to the decision;
+- counterclaim or limitation;
+- debt, owner, and review trigger when accepted.
+
+## Evidence
+
+Useful rationale evidence includes:
+
+- structured claim records;
+- local repository constraints;
+- cited design-rationale, HCI, accessibility, or tooling sources;
+- rendered evidence;
+- accessibility evidence;
+- task or persona review;
+- user or participant evidence when the claim requires it.
+
+## Blocking Conditions
+
+Block a rationale when:
+
+- it hides a tradeoff;
+- it lists sources without saying what each source can and cannot support;
+- it accepts accessibility debt without affected users and a review trigger;
+- it reopens layout scope without naming the local repo rule being changed.
+
+## Boundary
+
+Rationale does not need to be long. It needs to make the claim, warrant, evidence, and limitation inspectable.
+
+When a rationale contains a high-impact design claim, route it through the [structured quality claim template](../claims.md#claim-record-template) or link to an existing claim record.

--- a/quality/index.md
+++ b/quality/index.md
@@ -1,0 +1,24 @@
+# Quality Gates
+
+`quality/` records principle-backed claim gates for design-side judgments in `layout-gallery`.
+
+This layer does not turn the repository into a visual design system. Pattern files still own spatial structure only. Quality records explain how high-impact claims are framed, what evidence can support them, and when review or debt is required.
+
+## Concepts
+
+- [Structured quality claims](claims.md) - Claim-record template, high-impact scope, and low-risk prose boundary.
+- [Gate index](gates/index.md) - Gate contracts for design claims, rationale, and harmony evaluation.
+- [Evidence index](evidence/index.md) - Evidence-family vocabulary for claim records.
+- [Claim records](claim-records/index.md) - Filled examples for high-impact claims.
+
+## Admission Model
+
+Every high-impact non-layout design claim should follow this chain:
+
+```txt
+principle -> claim -> context -> warrant -> evidence family -> verification protocol -> boundary/debt
+```
+
+Evidence is not the gate. Evidence supports a claim only when the principle, gate, warrant, and boundary are explicit.
+
+High-impact claims use the [claim record template](claims.md#claim-record-template). Low-risk prose can stay as prose when it does not approve, block, redirect, or hand off implementation work.


### PR DESCRIPTION
## Summary

- Adds a self-contained `quality/` layer for structured quality claims.
- Adds claim-record template, evidence-family glossary, design/rationale/harmony gates, and three sample records.
- Keeps this PR atomic: excludes the broad dirty `pr-5` worktree, profiles, governance/IA/vocabulary axes, `.DS_Store`, and `.omo` evidence.

## Verification

- `node /Users/victor/Documents/StyleGallery/changeroa-StyleGallery-pr5-review/.omo/ulw-loop/axis-08-structured-quality-claims/evidence/check-structured-claims.mjs --root . --json --out .omo/ulw-loop/atomic-pr-axis-08/evidence/structured-claims.json`
- `node /Users/victor/Documents/StyleGallery/changeroa-StyleGallery-pr5-review/.omo/ulw-loop/axis-08-structured-quality-claims/evidence/check-structured-claims.mjs --fixture unsupported-high-impact --json --out .omo/ulw-loop/atomic-pr-axis-08/evidence/negative-unsupported-high-impact.json` (expected exit 2)
- `node /Users/victor/Documents/StyleGallery/changeroa-StyleGallery-pr5-review/.omo/ulw-loop/axis-08-structured-quality-claims/evidence/check-regression-semantics.mjs --root . --json --out .omo/ulw-loop/atomic-pr-axis-08/evidence/regression-semantics.json`
- `node scripts/validate-okf.mjs --json`
- `node scripts/validate-links.mjs --json`
- `node scripts/validate-catalog.mjs --json`
- `node scripts/validate-patterns.mjs --json`
- `node scripts/test-validate-patterns.mjs --json`
- `git diff --check`

Evidence log: `.omo/ulw-loop/atomic-pr-axis-08/evidence/final-verification-clean-worktree.log` (local only, not committed).
