### PR TITLE
Add accessibility semantics and cognitive-load guidance

### DIFF
--- a/patterns/centering/center.md
+++ b/patterns/centering/center.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/centering/super-center.md
+++ b/patterns/centering/super-center.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/containment/box.md
+++ b/patterns/containment/box.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/containment/clamped-card.md
+++ b/patterns/containment/clamped-card.md
@@ -57,7 +57,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/containment/content-limiter.md
+++ b/patterns/containment/content-limiter.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/containment/fluid-styles.md
+++ b/patterns/containment/fluid-styles.md
@@ -57,7 +57,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/card-grid.md
+++ b/patterns/grid-repetition/card-grid.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/columns.md
+++ b/patterns/grid-repetition/columns.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/dense-grid.md
+++ b/patterns/grid-repetition/dense-grid.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/grid-wrapper.md
+++ b/patterns/grid-repetition/grid-wrapper.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/masonry-approx.md
+++ b/patterns/grid-repetition/masonry-approx.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/page-grid.md
+++ b/patterns/grid-repetition/page-grid.md
@@ -61,7 +61,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/ram-grid.md
+++ b/patterns/grid-repetition/ram-grid.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/grid-repetition/twelve-span-grid.md
+++ b/patterns/grid-repetition/twelve-span-grid.md
@@ -63,7 +63,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/badge-list.md
+++ b/patterns/in-line-grouping/badge-list.md
@@ -65,7 +65,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/breadcrumb.md
+++ b/patterns/in-line-grouping/breadcrumb.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/cluster.md
+++ b/patterns/in-line-grouping/cluster.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/deconstructed-pancake.md
+++ b/patterns/in-line-grouping/deconstructed-pancake.md
@@ -63,7 +63,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/pagination.md
+++ b/patterns/in-line-grouping/pagination.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/reel.md
+++ b/patterns/in-line-grouping/reel.md
@@ -61,7 +61,11 @@ Pattern owns the named scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: Pattern owns the named scroll container.
+- Cognitive risk: Medium: scroll ownership can hide context, controls, or return points if it is not named in the consuming layout.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/split-nav.md
+++ b/patterns/in-line-grouping/split-nav.md
@@ -68,7 +68,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/tab-strip.md
+++ b/patterns/in-line-grouping/tab-strip.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/in-line-grouping/wrap-row.md
+++ b/patterns/in-line-grouping/wrap-row.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/media-fit/frame.md
+++ b/patterns/media-fit/frame.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/media-fit/icon-frame.md
+++ b/patterns/media-fit/icon-frame.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/overlay-exception/imposter.md
+++ b/patterns/overlay-exception/imposter.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/overlay-exception/overlay-stack.md
+++ b/patterns/overlay-exception/overlay-stack.md
@@ -60,7 +60,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/list-detail.md
+++ b/patterns/split-sidebar/list-detail.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/main-with-rail.md
+++ b/patterns/split-sidebar/main-with-rail.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/media-object.md
+++ b/patterns/split-sidebar/media-object.md
@@ -73,7 +73,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/sidebar.md
+++ b/patterns/split-sidebar/sidebar.md
@@ -72,7 +72,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/split-screen.md
+++ b/patterns/split-sidebar/split-screen.md
@@ -63,7 +63,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/sticky-aside.md
+++ b/patterns/split-sidebar/sticky-aside.md
@@ -68,7 +68,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/supporting-pane.md
+++ b/patterns/split-sidebar/supporting-pane.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/split-sidebar/switcher.md
+++ b/patterns/split-sidebar/switcher.md
@@ -64,7 +64,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/stacking/feed.md
+++ b/patterns/stacking/feed.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/stacking/line-up.md
+++ b/patterns/stacking/line-up.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/stacking/stack.md
+++ b/patterns/stacking/stack.md
@@ -58,7 +58,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/stacking/step-nav.md
+++ b/patterns/stacking/step-nav.md
@@ -59,7 +59,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/cover.md
+++ b/patterns/viewport-shell/cover.md
@@ -61,7 +61,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/fixed-sidenav-shell.md
+++ b/patterns/viewport-shell/fixed-sidenav-shell.md
@@ -68,7 +68,11 @@ Pattern owns the named scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: Pattern owns the named scroll container.
+- Cognitive risk: Medium: scroll ownership can hide context, controls, or return points if it is not named in the consuming layout.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/holy-grail.md
+++ b/patterns/viewport-shell/holy-grail.md
@@ -83,7 +83,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/panel-layout.md
+++ b/patterns/viewport-shell/panel-layout.md
@@ -66,7 +66,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/scroll-body-shell.md
+++ b/patterns/viewport-shell/scroll-body-shell.md
@@ -64,7 +64,11 @@ Pattern owns the named scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: Pattern owns the named scroll container.
+- Cognitive risk: Medium: scroll ownership can hide context, controls, or return points if it is not named in the consuming layout.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/sticky-footer.md
+++ b/patterns/viewport-shell/sticky-footer.md
@@ -63,7 +63,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/patterns/viewport-shell/sticky-header.md
+++ b/patterns/viewport-shell/sticky-header.md
@@ -57,7 +57,11 @@ No internal scroll container.
 
 ## Accessibility And Source Order Notes
 
-Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.
+- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.
+- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.
+- Scroll expectation: No internal scroll container.
+- Cognitive risk: Low: the pattern should preserve ordinary reading flow when semantic order is already correct.
 
 ## Browser And Fallback Notes
 

--- a/quality/evidence/accessibility.md
+++ b/quality/evidence/accessibility.md
@@ -8,6 +8,21 @@ description: Accessibility evidence sources and limits.
 
 Accessibility evidence combines standards, automated checks, manual review, and user-context judgment.
 
+## Claim Classification Register
+
+Every accessibility claim must name one verification method before it is used in a quality record.
+
+| Verification method | Supports | Does not support | Required record |
+| --- | --- | --- | --- |
+| automated | Rule-scoped checks such as axe, ACT, contrast math, lint rules, or validator output. | Keyboard logic, screen-reader comprehension, task success, or cognitive load beyond the tested rule. | Tool name, rule set, scope, date, and unresolved findings. |
+| manual | Expert review of DOM/source order, focus order, keyboard behavior, screen-reader flow, motion comfort, language clarity, or cognitive load. | Representative user comprehension or population-level accessibility. | Reviewer, scenario, viewport/device if relevant, observed pass/fail, and debt. |
+| user | Participant evidence for task completion, comprehension, perceived effort, or assistive-technology fit. | General compliance outside the tested audience and scenario. | Audience, task, method, sample limits, outcome, and follow-up trigger. |
+| debt | A known gap accepted for a bounded reason. | A positive accessibility claim. | Affected users, risk, owner, review trigger, and expiry condition. |
+
+## Quality Claim Linkage
+
+Quality claims that mention accessibility must link directly to one register row and one evidence artifact. If the claim depends on multiple facts, split it: for example, contrast may be `automated`, while keyboard order and cognitive load require `manual` or `user` evidence.
+
 ## Evidence Types
 
 - WCAG-oriented checks;
@@ -31,6 +46,7 @@ Accessibility evidence combines standards, automated checks, manual review, and 
 - universal task completion;
 - cognitive accessibility for every user;
 - assistive technology behavior that was not tested.
+- accessibility from a screenshot, visual diff, generated image, or GPT Image reference.
 
 ## Required Phrase
 

--- a/quality/gates/accessibility-evidence.md
+++ b/quality/gates/accessibility-evidence.md
@@ -21,11 +21,23 @@ Use this gate when a claim affects access, comprehension, keyboard use, screen-r
 - screen-reader or accessibility-tree review when the claim depends on semantics;
 - cognitive accessibility review for language, memory burden, predictability, and help.
 
+## Verification Method Register
+
+Classify every accessibility claim before approval:
+
+- `automated`: rule-scoped machine checks such as axe, ACT, contrast math, lint output, or validator output.
+- `manual`: expert review of DOM order, focus order, keyboard behavior, screen-reader flow, language clarity, motion comfort, or cognitive load.
+- `user`: participant evidence for task completion, comprehension, assistive-technology fit, or perceived effort.
+- `debt`: a known accessibility gap with affected users, owner, review trigger, and expiry condition.
+
+The claim record must include the verification method, the evidence artifact, the boundary, and any accepted debt. A rendered screenshot, visual diff, generated image, or GPT Image reference can be supporting context only; it is not an accessibility verification method.
+
 ## Required Boundary Language
 
 - Automated accessibility scans assist evaluation, not determine accessibility.
 - Passing an automated scan means no issue was found by that tested rule set.
 - Manual judgment is required for claims involving task completion, cognitive load, clarity, assistive technology behavior, or user comprehension.
+- Visual evidence cannot prove accessibility unless it is paired with the relevant automated, manual, user, or debt record.
 
 ## Blocking Conditions
 

--- a/quality/gates/visual-evidence.md
+++ b/quality/gates/visual-evidence.md
@@ -24,6 +24,7 @@ Use this gate when a claim depends on rendered output, visual state, hierarchy, 
 
 - Screenshot diffs show rendered change, not usability.
 - A stable visual diff does not prove accessibility.
+- Generated images, GPT Image references, and screenshots are not accessibility proof.
 - A visual QA pass does not prove brand fit or aesthetic quality.
 - Visual review must cite the principle, task, state, or brief it evaluates.
 

--- a/quality/index.md
+++ b/quality/index.md
@@ -9,6 +9,7 @@ This layer does not make the repository a visual design system. Pattern files st
 - [Quality principles](principles.md) - Principles shared by the quality gate layer.
 - [Gate index](gates/index.md) - Gate contracts for layout, design claims, visual evidence, accessibility evidence, and rationale.
 - [Evidence index](evidence/index.md) - Reference sources and evidence boundaries for design-side claims.
+- [Accessibility evidence register](evidence/accessibility.md) - Classification for accessibility claims: automated, manual, user, or debt.
 
 ## Admission Model
 

--- a/recipes/article-page.md
+++ b/recipes/article-page.md
@@ -23,6 +23,12 @@ Place the article before supplemental aside content when the article is the prim
 
 The document owns scrolling. The aside may become sticky, but it should not introduce an independent scroll container unless the aside content is longer than the viewport and has a declared overflow behavior.
 
+## Accessibility Expectations
+
+- Focus expectation: Article links and controls follow the article's DOM order before moving to supplemental aside content unless the aside is the active task.
+- Scroll expectation: Sticky aside behavior must not cover headings, anchors, or focused links while the document scrolls.
+- Cognitive risk: Supplemental content can interrupt reading flow; keep references close to the article section they support.
+
 ## Responsive Behavior
 
 At narrow widths, aside content should fall into document flow after the related article region. Keep references close to the content they support.

--- a/recipes/command-surface.md
+++ b/recipes/command-surface.md
@@ -23,6 +23,15 @@ Place primary commands before secondary command groups when they operate on the 
 
 The shell body owns content scrolling. Command rows should wrap when possible; use [reel](../patterns/in-line-grouping/reel.md) only when horizontal scanning is part of the interaction model.
 
+## Accessibility Checklist
+
+- Source order: Put primary commands before secondary commands and before the content region they affect when the command is the task entry point.
+- Focus expectation: Keyboard focus must reach every command, preserve visible focus, and return to the edited or inspected content after command execution when appropriate.
+- Scroll expectation: Keep fixed command regions outside the body scroll container; if command groups overflow horizontally, provide a named scroll model and keyboard path.
+- Semantic risk: Icon-only or compact commands need accessible names, state, and grouping before layout classes compress them.
+- Cognitive risk: Tool-heavy surfaces increase recognition and mode burden; keep command grouping stable and avoid moving commands between breakpoints without a documented overflow model.
+- Verification method: Pair `automated` accessible-name checks with `manual` keyboard traversal, focus-return, and mode-state review; reserve `debt` for commands that intentionally require later assistive-technology testing.
+
 ## Responsive Behavior
 
 At narrow widths, command groups should wrap into stable rows or move into a declared overflow region. Do not let command text resize the shell.

--- a/recipes/dashboard.md
+++ b/recipes/dashboard.md
@@ -23,6 +23,15 @@ Order panels by decision priority, not by visual symmetry. Headings and filters 
 
 Prefer normal document scrolling. Introduce internal scroll containers only for panels whose independent scroll state is part of the task.
 
+## Accessibility Checklist
+
+- Source order: Order panels by the decision path a reader should follow; do not let grid placement make lower-priority panels read first.
+- Focus expectation: Filters, chart controls, and panel actions must follow the same priority order as their controlled regions.
+- Scroll expectation: If a panel scrolls internally, name the panel, keep its heading outside or at the start of that scroll region, and verify focus is not trapped inside it.
+- Semantic risk: Repeated metric cards can become anonymous groups; use headings, table/list semantics, or labelled regions before applying grid classes.
+- Cognitive risk: Dense dashboards increase comparison load; group metrics by task and avoid relying on position or color alone to explain status.
+- Verification method: Combine `automated` landmark/heading/contrast checks with `manual` keyboard, source-order, and cognitive walkthrough evidence; use `user` evidence for task-completion claims.
+
 ## Responsive Behavior
 
 Let repeated panels reflow through grid constraints before adding viewport breakpoints. Action clusters should wrap before they overflow.

--- a/recipes/form-flow.md
+++ b/recipes/form-flow.md
@@ -23,6 +23,15 @@ Keep labels, descriptions, fields, and errors adjacent in DOM order. Group relat
 
 Prefer document scrolling. If actions must remain visible, use a shell or footer pattern only after confirming it does not obscure validation messages or focus targets.
 
+## Accessibility Checklist
+
+- Source order: Keep each label, description, input, hint, and error adjacent in DOM order, even when groups are visually split into columns.
+- Focus expectation: Keyboard focus must move through fields, validation messages, and actions in the same sequence a user completes the form.
+- Scroll expectation: Sticky or fixed actions must not cover focused fields, inline errors, or the first invalid field after submission.
+- Semantic risk: Group related controls with fieldset/legend or labelled sections before adding stack or cluster layout classes.
+- Cognitive risk: Long flows create memory burden; expose step context, error recovery, and required/optional state without depending on color alone.
+- Verification method: Use `automated` form-name/error association checks where possible, then `manual` keyboard and error-recovery review; use `user` evidence for completion-rate or comprehension claims.
+
 ## Responsive Behavior
 
 Field groups should stack naturally. Action groups should wrap before they overflow and should preserve a clear primary action position.

--- a/recipes/list-detail.md
+++ b/recipes/list-detail.md
@@ -23,6 +23,15 @@ Place list controls before list results. Place detail content after the list in 
 
 Name whether the list, the detail region, or the page body owns scrolling. Avoid making both list and detail scroll independently unless the task requires side-by-side comparison.
 
+## Accessibility Checklist
+
+- Source order: Put list controls before list results, then the selected detail, unless the detail is the primary entry point for the task.
+- Focus expectation: Selecting a list item must either keep focus on the selected item with the detail announced by context, or move focus to the detail heading with a documented return path.
+- Scroll expectation: If list and detail scroll independently, name both regions and verify keyboard users can reach and leave each scroll container.
+- Semantic risk: The list, selected state, and detail region need roles, headings, or labels that expose their relationship before split-sidebar layout is applied.
+- Cognitive risk: Users can lose context when selection changes the detail region; preserve selected state, count/position, and clear return behavior.
+- Verification method: Use `automated` landmark/name checks, `manual` focus-return and scroll-container review, and `user` evidence for browse-and-compare task success claims.
+
 ## Responsive Behavior
 
 At narrow widths, the list and detail regions should stack in a predictable order. Preserve focus return behavior when selecting an item changes the detail region.

--- a/recipes/saas-settings.md
+++ b/recipes/saas-settings.md
@@ -23,6 +23,12 @@ Place the navigation before the main settings region when it is the first meanin
 
 The main region owns vertical scrolling. The side navigation remains stable. Avoid adding independent scrolling to individual settings groups unless a group has a named overflow responsibility.
 
+## Accessibility Expectations
+
+- Focus expectation: Side-navigation links move predictably into the matching settings section, and focus remains visible when the main region scrolls.
+- Scroll expectation: The stable navigation must not create a second hidden scroll path; each settings group should rely on the main region unless overflow is declared.
+- Cognitive risk: Settings pages mix navigation and editing; use headings, save-state labels, and grouping so users do not lose the current section.
+
 ## Responsive Behavior
 
 At narrow widths, navigation may become an inline region above the main content. Preserve source order and avoid visually reordering sections ahead of their headings.

--- a/scripts/generate-patterns.mjs
+++ b/scripts/generate-patterns.mjs
@@ -39,6 +39,16 @@ function inlineCodeList(values) {
   return values.map((value) => `\`${value}\``).join(", ");
 }
 
+function cognitiveRisk(pattern) {
+  if (pattern.scrollOwnership && !pattern.scrollOwnership.startsWith("No internal")) {
+    return "Medium: scroll ownership can hide context, controls, or return points if it is not named in the consuming layout.";
+  }
+  if (pattern.responsiveness === "reflow") {
+    return "Medium: reflow can change spatial adjacency, so labels, controls, and related content must remain adjacent in DOM order.";
+  }
+  return "Low: the pattern should preserve ordinary reading flow when semantic order is already correct.";
+}
+
 function contractSections(pattern, rootClass) {
   const properties = declarationNames(pattern);
   const core = inlineCodeList(properties);
@@ -62,7 +72,11 @@ function contractSections(pattern, rootClass) {
     "",
     "## Accessibility And Source Order Notes",
     "",
-    "Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.",
+    "- Semantic role expectation: Preserve the HTML sample's landmark, list, navigation, form, figure, or article roles; layout classes must not replace semantic elements.",
+    "- DOM order expectation: Keep semantic elements, DOM order, reading order, and focus order independent from the visual placement created by the layout classes.",
+    "- Focus risk: Any interactive descendants follow DOM order; do not use this pattern to create a visual order that keyboard focus cannot follow.",
+    `- Scroll expectation: ${pattern.scrollOwnership ?? "No internal scroll container."}`,
+    `- Cognitive risk: ${cognitiveRisk(pattern)}`,
     "",
     "## Browser And Fallback Notes",
     "",

--- a/scripts/test-validate-patterns.mjs
+++ b/scripts/test-validate-patterns.mjs
@@ -57,6 +57,12 @@ const cases = [
     expect: "missing Core Properties section",
   },
   {
+    name: "missing_accessibility_risk_details",
+    file: "patterns/stacking/bad.md",
+    content: legacyPattern("bad", "Stacking", ".bad {\n    display: grid;\n}"),
+    expect: "missing accessibility risk detail",
+  },
+  {
     name: "contract_sections_inside_code_block",
     file: "patterns/stacking/bad.md",
     content: legacyPattern(
@@ -112,7 +118,7 @@ function legacyPattern(name, category, css, html = `<section class="${name}"></s
 
 function pattern(name, category, css, html = `<section class="${name}"></section>`, responsiveness = "fluid") {
   const cssBlock = css ? `\n\`\`\`css\n${css}\n\`\`\`\n` : "\n";
-  return `---\nname: ${name}\ncategory: ${category}\nprimary_spatial_problem: Test spatial problem.\nsecondary_spatial_problems: none\nlayout_axis: block\ncontent_shape: mixed\nresponsiveness: ${responsiveness}\nconstraints: Test constraints.\nscroll_ownership: No internal scroll container.\nsource_lineage: test\n---\n\n# ${name}\n\n## When To Use\n\nUse for validation tests.\n\n## HTML\n\n\`\`\`html\n${html}\n\`\`\`\n\n## CSS\n${cssBlock}\n## Core Properties\n\n- \`display\` establishes the layout context.\n\n## Properties That Break The Layout If Removed\n\n- Removing \`display\` removes the layout behavior.\n\n## Constraints And Change Points\n\nTest constraints.\n\n## Scroll Ownership\n\nNo internal scroll container.\n\n## Accessibility And Source Order Notes\n\nKeep semantic order.\n\n## Browser And Fallback Notes\n\nUse a simpler block fallback when needed.\n\n## Composition Notes\n\nCompose with semantic regions.\n\n## Anti-patterns\n\nDo not use for unrelated visual styling.\n`;
+  return `---\nname: ${name}\ncategory: ${category}\nprimary_spatial_problem: Test spatial problem.\nsecondary_spatial_problems: none\nlayout_axis: block\ncontent_shape: mixed\nresponsiveness: ${responsiveness}\nconstraints: Test constraints.\nscroll_ownership: No internal scroll container.\nsource_lineage: test\n---\n\n# ${name}\n\n## When To Use\n\nUse for validation tests.\n\n## HTML\n\n\`\`\`html\n${html}\n\`\`\`\n\n## CSS\n${cssBlock}\n## Core Properties\n\n- \`display\` establishes the layout context.\n\n## Properties That Break The Layout If Removed\n\n- Removing \`display\` removes the layout behavior.\n\n## Constraints And Change Points\n\nTest constraints.\n\n## Scroll Ownership\n\nNo internal scroll container.\n\n## Accessibility And Source Order Notes\n\n- Semantic role expectation: Preserve the element roles already present in the HTML sample.\n- DOM order expectation: Keep semantic order.\n- Focus risk: Keep focus order aligned with DOM order.\n- Scroll expectation: No internal scroll container.\n- Cognitive risk: Low when the pattern does not reorder meaning or hide controls.\n\n## Browser And Fallback Notes\n\nUse a simpler block fallback when needed.\n\n## Composition Notes\n\nCompose with semantic regions.\n\n## Anti-patterns\n\nDo not use for unrelated visual styling.\n`;
 }
 
 function runCase(testCase) {

--- a/scripts/validate-patterns.mjs
+++ b/scripts/validate-patterns.mjs
@@ -38,6 +38,14 @@ const requiredSections = [
   "## Anti-patterns",
 ];
 
+const requiredAccessibilityDetails = [
+  "Semantic role expectation:",
+  "DOM order expectation:",
+  "Focus risk:",
+  "Scroll expectation:",
+  "Cognitive risk:",
+];
+
 const forbiddenProperties = [
   "animation",
   "background",
@@ -201,6 +209,9 @@ for (const absolute of files) {
   const markdown = stripFencedCodeBlocks(content);
   for (const section of requiredSections) {
     if (!hasHeading(markdown, section)) failures.push(`${file}: missing ${section.replace("## ", "")} section`);
+  }
+  for (const detail of requiredAccessibilityDetails) {
+    if (!markdown.includes(detail)) failures.push(`${file}: missing accessibility risk detail ${detail}`);
   }
   const html = codeBlock(content, "html");
   if (!html) failures.push(`${file}: missing html code block`);


### PR DESCRIPTION
## Summary
- Adds an accessibility evidence classification register for automated/manual/user/debt verification.
- Extends generated pattern docs with semantic role, DOM order, focus risk, scroll expectation, and cognitive risk fields.
- Adds high-risk recipe accessibility checklists and reinforces visual-evidence accessibility proof boundaries.

## Atomicity
This is a stacked atomic PR against `codex/axis-07-quality-gates-base` (`6f575c9`). The PR contains one commit:

- `a185d22 Add accessibility semantics and cognitive-load guidance`

Excluded from this PR: governance, IA, vocabulary, search-metadata, `.github`, lifecycle/generated-warning, and unrelated workflow files.

## Verification
- `git diff --cached --check`
- forbidden path scan: no governance/IA/vocabulary/search-metadata/.github paths
- forbidden generator scan: no generated-warning/lifecycle/generated_from/IA Navigation/Primary role hunks
- `node -c scripts/generate-patterns.mjs`
- `node -c scripts/validate-patterns.mjs`
- `node -c scripts/test-validate-patterns.mjs`
- `node scripts/validate-patterns.mjs --json --min-count 46`
- `node scripts/test-validate-patterns.mjs`
- `node scripts/validate-links.mjs --json`

Evidence is saved locally under `.omo/evidence/atomic-pr/`.
