### PR TITLE
Add pattern boundary guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,15 @@ This repository is `layout-gallery`: a gallery of minimal, portable CSS layout p
 - Make scroll responsibility obvious in both class names and CSS.
 - Keep decorative styling out of reusable pattern CSS.
 
+## Pattern Boundary Gate
+
+Before adding a new pattern or changing reusable pattern CSS, check [Layout Decision Tree](guides/decision-tree.md) and [Layout Brief Template](guides/layout-brief.md).
+
+- Decide whether the work is a new pattern, a recipe composition, or product styling outside this repository.
+- Name the layout owner, scroll owner, core layout declarations, excluded demo/product styling, and likely breaking content case.
+- For scroll or responsive changes, include the failure case the pattern prevents, such as a missing shrink constraint or a viewport breakpoint used for component-local behavior.
+- Add a new pattern only when existing patterns or recipes do not already cover the spatial responsibility.
+
 ## CSS Authoring
 
 - Use layout properties only unless a non-layout property is required to explain layout behavior.

--- a/guides/decision-tree.md
+++ b/guides/decision-tree.md
@@ -8,6 +8,65 @@ description: Question-driven route from screen constraints to layout-gallery pat
 
 Use this when the pattern name is not obvious yet.
 
+## Before Adding A Pattern
+
+Add a new pattern only when the spatial responsibility is not already covered by an existing pattern or recipe.
+
+- If the problem is composition, update or add a recipe.
+- If the problem is visual treatment, keep it outside reusable pattern CSS.
+- If the problem is repeated layout failure, document the smallest reusable pattern that prevents it.
+- If scroll, sizing, or wrapping ownership is unclear, clarify ownership before writing CSS.
+
+Examples:
+
+- Settings page with side navigation, readable form width, and action rows: recipe composition, not one large pattern.
+- Premium card treatment with shadows, color accents, and larger headings: product styling, not reusable pattern CSS.
+- Repeated action row that wraps badly across screens: candidate pattern if the wrapping responsibility is not covered by `cluster` or `wrap-row`.
+
+Code-level distinction:
+
+```html
+<div class="action_row">
+    <button type="button">Save changes</button>
+    <button type="button">Preview</button>
+    <button type="button">Discard draft</button>
+</div>
+```
+
+```css
+.action_row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--action-gap);
+}
+```
+
+This can be a reusable layout pattern only if the wrapping responsibility is not already covered by an existing pattern. Button colors, borders, shadows, and typography belong to the consuming product or demo layer.
+
+Viewport versus container-local example:
+
+```css
+/* Avoid for component-local layout: the parent container may be narrower than the viewport. */
+@media (min-width: 48rem) {
+    .action_row {
+        flex-wrap: nowrap;
+    }
+}
+```
+
+```css
+/* Prefer when the component should respond to its own available space. */
+.action_region {
+    container-type: inline-size;
+}
+
+@container (min-width: 32rem) {
+    .action_row {
+        flex-wrap: nowrap;
+    }
+}
+```
+
 ## Start With Scope
 
 ### Is the layout controlled by the viewport?

--- a/guides/layout-brief.md
+++ b/guides/layout-brief.md
@@ -60,8 +60,81 @@ Primary task:
 Primary content:
 Supporting content:
 Scroll owner:
+Pattern boundary:
 Pattern stack:
+Layout owner:
+Core layout declarations:
+Demo or product styling excluded:
 Constraints:
 Change points:
+Likely breaking content case:
 Patterns rejected:
+```
+
+Short examples:
+
+- New pattern: `Pattern boundary: repeated layout failure`, `Layout owner: tab_strip owns inline overflow`, `Demo or product styling excluded: active tab color`.
+- Recipe composition: `Pattern boundary: recipe composition`, `Pattern stack: fixed-sidenav-shell, content-limiter, stack`, `Patterns rejected: new settings-page pattern`.
+- Product styling: `Pattern boundary: product styling`, `Core layout declarations: card-grid placement only`, `Demo or product styling excluded: shadows, radius, color accents`.
+
+Minimal code example:
+
+```html
+<section class="settings_shell" aria-label="Settings">
+    <nav class="settings_shell_nav" aria-label="Settings sections"></nav>
+    <main class="settings_shell_scroll_area"></main>
+</section>
+```
+
+```css
+.settings_shell {
+    block-size: 100dvb;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+}
+
+.settings_shell_scroll_area {
+    min-block-size: 0;
+    overflow: auto;
+}
+```
+
+In this example, `settings_shell` owns viewport sizing and columns, `settings_shell_scroll_area` owns scrolling, and visual treatment such as active nav color, borders, shadows, and typography stays outside the reusable layout CSS.
+
+Failure example:
+
+```css
+/* Avoid: overflow is named, but the grid child may refuse to shrink. */
+.settings_shell_scroll_area {
+    overflow: auto;
+}
+```
+
+```css
+/* Prefer: the scroll owner can shrink inside the shell track. */
+.settings_shell_scroll_area {
+    min-block-size: 0;
+    overflow: auto;
+}
+```
+
+Styling boundary example:
+
+```css
+/* Avoid in reusable pattern CSS: layout and product styling are mixed. */
+.settings_shell_scroll_area {
+    background: var(--panel-background);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    min-block-size: 0;
+    overflow: auto;
+}
+```
+
+```css
+/* Prefer in reusable pattern CSS: only the scroll responsibility remains. */
+.settings_shell_scroll_area {
+    min-block-size: 0;
+    overflow: auto;
+}
 ```

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 # layout-gallery Log
 
+## 2026-07-09
+
+- Added short pattern-boundary examples to the existing planning guides.
+- Added pattern-boundary fields to the layout brief template.
+- Added a pre-pattern decision gate to the decision tree.
+- Linked the agent instructions to the pattern-boundary decision flow.
+- Added short bad/good CSS examples for scroll ownership, styling boundaries, and container-local responsiveness.
+
 ## 2026-07-04
 
 - Fixed fixed-sidenav-shell scroll activation by constraining grid-template-rows with minmax(0, 1fr) and min-block-size on panes.


### PR DESCRIPTION
## Summary
- Add a pre-pattern decision gate for distinguishing new patterns, recipe composition, and product styling
- Extend the layout brief with ownership, excluded styling, and likely breaking-case fields
- Add compact HTML/CSS bad-good examples for scroll ownership, styling boundaries, and container-local responsiveness
- Link agent instructions to the pattern-boundary decision flow

## Verification
- node scripts/validate-links.mjs
- node scripts/validate-okf.mjs
- node scripts/validate-catalog.mjs
- node scripts/validate-patterns.mjs