### PR TITLE
Relax documentation wording validation

### DIFF
--- a/scripts/test-validate-vocabulary.mjs
+++ b/scripts/test-validate-vocabulary.mjs
@@ -104,6 +104,13 @@ const cases = [
     expect: "guides/vocabulary.md: missing Prose linting should wait until the vocabulary is stable.",
   },
   {
+    name: "paraphrased_navigation_label",
+    mutate: {
+      "README.md": files["README.md"].replace("[Controlled vocabulary]", "[Vocabulary guide]"),
+    },
+    expectWarning: "README.md: recommended link label missing [Controlled vocabulary](guides/vocabulary.md)",
+  },
+  {
     name: "success_path",
     expect: null,
   },
@@ -128,11 +135,15 @@ function runCase(testCase) {
   });
   fs.rmSync(dir, { force: true, recursive: true });
   const output = JSON.parse(result.stdout);
-  const passed = testCase.expect ? !output.ok && output.failures.includes(testCase.expect) : output.ok;
+  const passed = testCase.expectWarning
+    ? output.ok && output.warnings?.includes(testCase.expectWarning)
+    : testCase.expect
+      ? !output.ok && output.failures.includes(testCase.expect)
+      : output.ok;
   return {
     name: testCase.name,
     ok: passed,
-    expected: testCase.expect ?? "ok:true",
+    expected: testCase.expectWarning ?? testCase.expect ?? "ok:true",
     actual: output,
   };
 }

--- a/scripts/test-validate-webpage-workflow.mjs
+++ b/scripts/test-validate-webpage-workflow.mjs
@@ -174,6 +174,13 @@ const cases = [
     expect: "guides/layout-brief.md: missing ## Rejected Alternatives",
   },
   {
+    name: "paraphrased_navigation_label",
+    mutate: {
+      "README.md": files["README.md"].replace("[Webpage Generation Workflow]", "[Webpage planning workflow]"),
+    },
+    expectWarning: "README.md: recommended link label missing [Webpage Generation Workflow](guides/webpage-generation-workflow.md)",
+  },
+  {
     name: "success_path",
     expect: null,
   },
@@ -200,11 +207,15 @@ function runCase(testCase) {
   });
   fs.rmSync(dir, { force: true, recursive: true });
   const output = JSON.parse(result.stdout);
-  const passed = testCase.expect ? !output.ok && output.failures.includes(testCase.expect) : output.ok;
+  const passed = testCase.expectWarning
+    ? output.ok && output.warnings?.includes(testCase.expectWarning)
+    : testCase.expect
+      ? !output.ok && output.failures.includes(testCase.expect)
+      : output.ok;
   return {
     name: testCase.name,
     ok: passed,
-    expected: testCase.expect ?? "ok:true",
+    expected: testCase.expectWarning ?? testCase.expect ?? "ok:true",
     actual: output,
   };
 }

--- a/scripts/validate-vocabulary.mjs
+++ b/scripts/validate-vocabulary.mjs
@@ -7,6 +7,7 @@ const args = new Set(process.argv.slice(2));
 const json = args.has("--json");
 const root = process.cwd();
 const failures = [];
+const warnings = [];
 
 const glossaryFile = "guides/vocabulary.md";
 const requiredTerms = [
@@ -23,10 +24,6 @@ const requiredTerms = [
 ];
 
 const requiredIncludes = {
-  "README.md": ["[Controlled vocabulary](guides/vocabulary.md)"],
-  "GUIDE.md": ["[Controlled vocabulary](guides/vocabulary.md)"],
-  "index.md": ["[Controlled vocabulary](guides/vocabulary.md)"],
-  "quality/index.md": ["[Controlled vocabulary](../guides/vocabulary.md)"],
   [glossaryFile]: [
     "## Canonical Terms",
     "## Aliases",
@@ -36,6 +33,13 @@ const requiredIncludes = {
     "## Vale Proposal",
     "Prose linting should wait until the vocabulary is stable.",
   ],
+};
+
+const recommendedLinks = {
+  "README.md": { target: "guides/vocabulary.md", preferred: "[Controlled vocabulary](guides/vocabulary.md)" },
+  "GUIDE.md": { target: "guides/vocabulary.md", preferred: "[Controlled vocabulary](guides/vocabulary.md)" },
+  "index.md": { target: "guides/vocabulary.md", preferred: "[Controlled vocabulary](guides/vocabulary.md)" },
+  "quality/index.md": { target: "../guides/vocabulary.md", preferred: "[Controlled vocabulary](../guides/vocabulary.md)" },
 };
 
 function read(relative) {
@@ -52,6 +56,12 @@ for (const [relative, snippets] of Object.entries(requiredIncludes)) {
   for (const snippet of snippets) {
     if (!content.includes(snippet)) failures.push(`${relative}: missing ${snippet}`);
   }
+}
+
+for (const [relative, link] of Object.entries(recommendedLinks)) {
+  const content = read(relative);
+  if (!content.includes(`](${link.target})`)) failures.push(`${relative}: missing link target ${link.target}`);
+  if (!content.includes(link.preferred)) warnings.push(`${relative}: recommended link label missing ${link.preferred}`);
 }
 
 const glossary = read(glossaryFile);
@@ -82,16 +92,17 @@ for (const record of canonicalRecords) {
 
 const result = {
   ok: failures.length === 0,
-  checkedFiles: Object.keys(requiredIncludes),
+  checkedFiles: [...new Set([...Object.keys(requiredIncludes), ...Object.keys(recommendedLinks)])],
   requiredTerms,
   canonicalTerms,
   failures,
+  warnings,
 };
 
 if (json) {
   console.log(JSON.stringify(result, null, 2));
 } else if (result.ok) {
-  console.log(`ok: ${canonicalTerms.length} canonical vocabulary terms`);
+  console.log(`ok: ${canonicalTerms.length} canonical vocabulary terms (${warnings.length} warnings)`);
 } else {
   console.error(failures.join("\n"));
 }

--- a/scripts/validate-webpage-workflow.mjs
+++ b/scripts/validate-webpage-workflow.mjs
@@ -7,19 +7,10 @@ const args = new Set(process.argv.slice(2));
 const json = args.has("--json");
 const root = process.cwd();
 const failures = [];
+const warnings = [];
 const contents = new Map();
 
 const requiredIncludes = {
-  "README.md": [
-    "[Webpage Generation Workflow](guides/webpage-generation-workflow.md)",
-  ],
-  "GUIDE.md": [
-    "[Webpage generation workflow](guides/webpage-generation-workflow.md)",
-    "content-to-layout match",
-    "harmony evaluation",
-    "GPT Image reference",
-    "implementation handoff",
-  ],
   "guides/layout-brief.md": [
     "## Webpage Generation Intake",
     "Content-to-layout match:",
@@ -62,9 +53,6 @@ const requiredIncludes = {
     "### Form Route",
     "### Command Surface Route",
   ],
-  "recipes/index.md": [
-    "[Homepage](homepage.md)",
-  ],
   "recipes/homepage.md": [
     "type: Layout Recipe",
     "screen_type: Homepage",
@@ -73,9 +61,6 @@ const requiredIncludes = {
     "## GPT Image Reference",
     "Required preconditions before prompt:",
     "Image review extract-vs-ignore:",
-  ],
-  "quality/gates/index.md": [
-    "[Harmony evaluation gate](harmony-evaluation.md)",
   ],
   "quality/gates/harmony-evaluation.md": [
     "type: Quality Gate",
@@ -88,6 +73,22 @@ const requiredIncludes = {
     "Do not generate a GPT Image reference before harmony evaluation approves the semantic order, section jobs, pattern stack, scroll owner, and constraints.",
     "Source order, accessibility, brand correctness, and usability cannot be inferred from the image.",
     "Final implementation proof:",
+  ],
+};
+
+const requiredLinks = {
+  "README.md": { target: "guides/webpage-generation-workflow.md", preferred: "[Webpage Generation Workflow](guides/webpage-generation-workflow.md)" },
+  "GUIDE.md": { target: "guides/webpage-generation-workflow.md", preferred: "[Webpage generation workflow](guides/webpage-generation-workflow.md)" },
+  "recipes/index.md": { target: "homepage.md", preferred: "[Homepage](homepage.md)" },
+  "quality/gates/index.md": { target: "harmony-evaluation.md", preferred: "[Harmony evaluation gate](harmony-evaluation.md)" },
+};
+
+const recommendedIncludes = {
+  "GUIDE.md": [
+    "content-to-layout match",
+    "harmony evaluation",
+    "GPT Image reference",
+    "implementation handoff",
   ],
 };
 
@@ -128,6 +129,19 @@ for (const [relative, snippets] of Object.entries(requiredIncludes)) {
   const content = read(relative);
   for (const snippet of snippets) {
     if (!content.includes(snippet)) failures.push(`${relative}: missing ${snippet}`);
+  }
+}
+
+for (const [relative, link] of Object.entries(requiredLinks)) {
+  const content = read(relative);
+  if (!content.includes(`](${link.target})`)) failures.push(`${relative}: missing link target ${link.target}`);
+  if (!content.includes(link.preferred)) warnings.push(`${relative}: recommended link label missing ${link.preferred}`);
+}
+
+for (const [relative, snippets] of Object.entries(recommendedIncludes)) {
+  const content = read(relative);
+  for (const snippet of snippets) {
+    if (!content.includes(snippet)) warnings.push(`${relative}: recommended prose missing ${snippet}`);
   }
 }
 
@@ -176,15 +190,18 @@ for (const route of workflowRoutes) {
 
 const result = {
   ok: failures.length === 0,
-  checkedFiles: Object.keys(requiredIncludes),
-  checkedRequirements: Object.values(requiredIncludes).reduce((total, snippets) => total + snippets.length, 0),
+  checkedFiles: [...new Set([...Object.keys(requiredIncludes), ...Object.keys(requiredLinks), ...Object.keys(recommendedIncludes)])],
+  checkedRequirements: Object.values(requiredIncludes).reduce((total, snippets) => total + snippets.length, 0)
+    + Object.keys(requiredLinks).length
+    + Object.values(recommendedIncludes).reduce((total, snippets) => total + snippets.length, 0),
   failures,
+  warnings,
 };
 
 if (json) {
   console.log(JSON.stringify(result, null, 2));
 } else if (result.ok) {
-  console.log(`ok: ${result.checkedRequirements} webpage workflow requirements`);
+  console.log(`ok: ${result.checkedRequirements} webpage workflow requirements (${warnings.length} warnings)`);
 } else {
   console.error(result.failures.join("\n"));
 }


### PR DESCRIPTION
## Summary

- keep vocabulary terms, workflow structure, safety boundaries, route order, and link targets blocking
- move preferred navigation labels and selected GUIDE wording into `warnings`
- add paraphrase fixtures for vocabulary and webpage workflow validators

## Atomic scope

This is PR 2 of 3. It is independently based on `main`; merge after #17 for the intended review sequence.

## Verification

- `node scripts/test-validate-vocabulary.mjs --json`
- `node scripts/validate-vocabulary.mjs --json`
- `node scripts/test-validate-webpage-workflow.mjs --json`
- `node scripts/validate-webpage-workflow.mjs --json`
- `node scripts/validate-links.mjs --json`
- `git diff --check`