### PR TITLE
feat(agent): add agent-native wiki protocol surfaces

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -98,6 +98,45 @@ jobs:
           node -c playwright.config.mjs
           node -c tests/helpers/render-consumer-reference.mjs
           node -c tests/consumer-reference-sentinels.spec.mjs
+          node -c scripts/sg.mjs
+          node -c scripts/sg-mcp.mjs
+          node -c scripts/agent-native/a2a-projection.mjs
+          node -c scripts/agent-native/agui-projection.mjs
+          node -c scripts/agent-native/canonical-json.mjs
+          node -c scripts/agent-native/cli-adapter.mjs
+          node -c scripts/agent-native/events.mjs
+          node -c scripts/agent-native/execution.mjs
+          node -c scripts/agent-native/fixture.mjs
+          node -c scripts/agent-native/identity.mjs
+          node -c scripts/agent-native/immutable-store.mjs
+          node -c scripts/agent-native/knowledge.mjs
+          node -c scripts/agent-native/learning.mjs
+          node -c scripts/agent-native/learning-records.mjs
+          node -c scripts/agent-native/mcp-adapter.mjs
+          node -c scripts/agent-native/queries.mjs
+          node -c scripts/agent-native/registry.mjs
+          node -c scripts/agent-native/retrieval.mjs
+          node -c scripts/agent-native/self-description.mjs
+          node -c scripts/test-agent-adapter-conformance.mjs
+          node -c scripts/test-agent-conformance-receipt.mjs
+          node -c scripts/test-agent-events.mjs
+          node -c scripts/test-agent-execution-effects.mjs
+          node -c scripts/test-agent-execution-fixtures.mjs
+          node -c scripts/test-agent-execution-kernel.mjs
+          node -c scripts/test-agent-execution-learning.mjs
+          node -c scripts/test-agent-execution-lifecycle.mjs
+          node -c scripts/test-agent-execution-safety.mjs
+          node -c scripts/test-agent-execution-views.mjs
+          node -c scripts/test-agent-identity-integrity-cases.mjs
+          node -c scripts/test-agent-knowledge-kernel.mjs
+          node -c scripts/test-agent-learning.mjs
+          node -c scripts/test-agent-mcp.mjs
+          node -c scripts/test-agent-native-schemas.mjs
+          node -c scripts/test-agent-registry-mcp-integrity.mjs
+          node -c scripts/test-agent-registry-mutations.mjs
+          node -c scripts/test-agent-projections.mjs
+          node -c scripts/test-sg-cli.mjs
+          node -e 'JSON.parse(require("fs").readFileSync("consumer-reference/agent-native/registry.json"))'
           node -c scripts/baseline-contract.mjs
           node -c scripts/strict-json.mjs
           node -c scripts/calibration-raw-contract.mjs
@@ -199,6 +238,9 @@ jobs:
 
       - name: JSON CLI output integrity
         run: node scripts/test-json-cli-output.mjs
+
+      - name: Agent-native operation and protocol contracts
+        run: npm run test:agent-native
 
       - name: Shared promotion policy contract
         run: |

--- a/consumer-reference/agent-native/registry.json
+++ b/consumer-reference/agent-native/registry.json
@@ -1,0 +1,640 @@
+{
+  "fixture_ref": "sg:manifest/agent-native-fixture",
+  "records": [
+    {
+      "canonical_sha256": "d554c0754123354b09b237a9c0ebd9d203da57e7158342b092f877fb73b12ad2",
+      "media_type": "application/json",
+      "record_kind": "artifact_projection",
+      "repository_path": "design-engineering/reference-profiles/governed-local/editorial/profile.json",
+      "stable_ref": "sg:artifact/editorial-profile-source"
+    },
+    {
+      "claim_refs": [
+        "sg:claim/editorial-profile-addressable"
+      ],
+      "example_only": true,
+      "id": "editorial-reference-profile",
+      "maturity": "experimental",
+      "profile_kind": "governed_local",
+      "record_kind": "profile_projection",
+      "source_ref": "sg:artifact/editorial-profile-source",
+      "stable_ref": "sg:profile/editorial-reference-profile",
+      "support_status": "active",
+      "title": "Editorial reference profile"
+    },
+    {
+      "evidence_refs": [
+        "sg:evidence/editorial-profile-source"
+      ],
+      "governance_refs": [
+        "sg:governance/editorial-profile-addressable"
+      ],
+      "record_kind": "claim",
+      "scope": "repository_fixture",
+      "stable_ref": "sg:claim/editorial-profile-addressable",
+      "statement": "The governed editorial profile is addressable through an immutable StableRef and source projection.",
+      "subject_ref": "sg:profile/editorial-reference-profile",
+      "validation_refs": [
+        "sg:validation/editorial-profile-addressable"
+      ]
+    },
+    {
+      "claim_ref": "sg:claim/editorial-profile-addressable",
+      "independence_group": "governed-profile-source",
+      "polarity": "SUPPORT",
+      "record_kind": "evidence_link",
+      "source_ref": "sg:artifact/editorial-profile-source",
+      "stable_ref": "sg:evidence/editorial-profile-source"
+    },
+    {
+      "claim_ref": "sg:claim/editorial-profile-addressable",
+      "record_kind": "validation_report",
+      "stable_ref": "sg:validation/editorial-profile-addressable",
+      "status": "PASS",
+      "suite": "agent-native-fixture",
+      "validator_ref": "sg:validator/agent-native-fixture",
+      "validator_version": "agent-native-fixture-validator@1"
+    },
+    {
+      "claim_ref": "sg:claim/editorial-profile-addressable",
+      "decision": "ACCEPT",
+      "governor_ref": "sg:governor/stylegallery-maintainers",
+      "policy_version": "agent-native-read-policy@1",
+      "record_kind": "governance_decision",
+      "stable_ref": "sg:governance/editorial-profile-addressable"
+    },
+    {
+      "claim_ref": "sg:claim/editorial-profile-addressable",
+      "disposition": "ALLOW_READ",
+      "policy_version": "agent-native-read-policy@1",
+      "record_kind": "policy_disposition",
+      "stable_ref": "sg:policy/editorial-profile-read"
+    },
+    {
+      "command": "node scripts/test-sg-cli.mjs --json",
+      "expected": {
+        "exit_code": 0,
+        "report_ok": true,
+        "stderr": ""
+      },
+      "record_kind": "executable_fixture",
+      "stable_ref": "sg:artifact/sg-cli-conformance-test"
+    },
+    {
+      "record_kind": "validator",
+      "stable_ref": "sg:validator/agent-native-fixture",
+      "name": "StyleGallery agent-native fixture verifier",
+      "validator_version": "agent-native-fixture-validator@1",
+      "verification_scope": "immutable_fixture_execution_receipts"
+    },
+    {
+      "command": "node scripts/test-sg-cli.mjs --json",
+      "fixture_ref": "sg:manifest/agent-native-fixture",
+      "fixture_record_ref": "sg:artifact/sg-cli-conformance-test",
+      "fixture_version_id": "sg:artifact/sg-cli-conformance-test@sha256:451cda8812f954da0a50efd7faf2a12a635f3be1d3df431c541dafeb8b9df2dc",
+      "record_kind": "execution_receipt",
+      "result": {
+        "exit_code": 0,
+        "report_ok": true,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "result_sha256": "sha256:540eaa0982f28b71d3e7a819163e3ca9d664323bab960fd9b3ea095a242bc277",
+      "stable_ref": "sg:receipt/sg-cli-conformance",
+      "verification": {
+        "method": "captured-command-result",
+        "status": "PASS",
+        "verifier_ref": "sg:validator/agent-native-fixture",
+        "verifier_version": "agent-native-fixture-validator@1"
+      }
+    },
+    {
+      "claim_refs": [
+        "sg:claim/agent-native-read-conformance"
+      ],
+      "conformance_level": "fixture_verified",
+      "operation_refs": [
+        "sg:operation/claims",
+        "sg:operation/context",
+        "sg:operation/discover",
+        "sg:operation/ops",
+        "sg:operation/resolve",
+        "sg:operation/retrieve"
+      ],
+      "profile_id": "stylegallery-agent-native-read-v1",
+      "record_kind": "conformance_profile",
+      "stable_ref": "sg:profile/agent-native-read-conformance"
+    },
+    {
+      "evidence_refs": [
+        "sg:evidence/agent-native-read-conformance"
+      ],
+      "record_kind": "claim",
+      "scope": "committed_fixture",
+      "stable_ref": "sg:claim/agent-native-read-conformance",
+      "statement": "The public read operations share one deterministic immutable fixture registry.",
+      "subject_ref": "sg:profile/agent-native-read-conformance",
+      "validation_refs": [
+        "sg:validation/agent-native-read-conformance"
+      ]
+    },
+    {
+      "claim_ref": "sg:claim/agent-native-read-conformance",
+      "independence_group": "executable-cli-fixture",
+      "polarity": "SUPPORT",
+      "record_kind": "evidence_link",
+      "source_ref": "sg:artifact/sg-cli-conformance-test",
+      "stable_ref": "sg:evidence/agent-native-read-conformance"
+    },
+    {
+      "claim_ref": "sg:claim/agent-native-read-conformance",
+      "record_kind": "validation_report",
+      "stable_ref": "sg:validation/agent-native-read-conformance",
+      "status": "PASS",
+      "suite": "sg-cli-contract",
+      "validator_ref": "sg:validator/agent-native-fixture",
+      "validator_version": "agent-native-fixture-validator@1"
+    },
+    {
+      "conformance_profile_ref": "sg:profile/agent-native-read-conformance",
+      "name": "StyleGallery",
+      "protocol_surfaces": {
+        "a2a": "task_projection",
+        "ag_ui": "event_projection",
+        "cli": "json_read_commands",
+        "mcp": "read_only"
+      },
+      "record_kind": "agent_description",
+      "stable_ref": "sg:agent/stylegallery"
+    },
+    {
+      "adapters": [
+        "cli",
+        "mcp"
+      ],
+      "description": "Describe the agent-native StyleGallery surface and conformance profile.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "name": "discover",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/discover"
+    },
+    {
+      "adapters": [
+        "cli",
+        "mcp"
+      ],
+      "description": "Resolve one StableRef or VersionID to an immutable record.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "reference": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reference"
+        ],
+        "type": "object"
+      },
+      "name": "resolve",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/resolve"
+    },
+    {
+      "adapters": [
+        "cli",
+        "mcp"
+      ],
+      "description": "Return claims and their separate evidence, validation, governance, and policy records.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "reference": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reference"
+        ],
+        "type": "object"
+      },
+      "name": "claims",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/claims"
+    },
+    {
+      "adapters": [
+        "cli",
+        "mcp"
+      ],
+      "description": "Build a deterministic bounded context package for one reference.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "reference": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reference"
+        ],
+        "type": "object"
+      },
+      "name": "context",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/context"
+    },
+    {
+      "adapters": [
+        "cli",
+        "mcp"
+      ],
+      "description": "List deterministic operation specifications.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "name": "ops",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/ops"
+    },
+    {
+      "adapters": [
+        "mcp"
+      ],
+      "description": "Project a deterministic bounded retrieval view over fixture records.",
+      "effect_class": "NONE",
+      "idempotent": true,
+      "read_only": true,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "name": "retrieve",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "stable_ref": "sg:operation/retrieve"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Create an immutable governed-learning proposal without promoting it.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "changes": {
+            "type": "array"
+          },
+          "claim": {
+            "type": "object"
+          },
+          "evidence": {
+            "type": "array"
+          },
+          "proposer": {
+            "type": "string"
+          },
+          "stable_ref": {
+            "type": "string"
+          },
+          "validation": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "changes",
+          "claim",
+          "evidence",
+          "proposer",
+          "stable_ref",
+          "validation"
+        ],
+        "type": "object"
+      },
+      "name": "proposal.create",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/proposal-create",
+      "stable_ref": "sg:operation/proposal-create"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Verify a proposal with evidence from an independent actor.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "type": "array"
+          },
+          "proposal": {
+            "type": "object"
+          },
+          "validation": {
+            "type": "object"
+          },
+          "verifier": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "evidence",
+          "proposal",
+          "validation",
+          "verifier"
+        ],
+        "type": "object"
+      },
+      "name": "proposal.verify",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/proposal-verify",
+      "stable_ref": "sg:operation/proposal-verify"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Record an attributed governance decision for a verified proposal.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "governance_decision": {
+            "type": "object"
+          },
+          "proposal": {
+            "type": "object"
+          },
+          "verification": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "governance_decision",
+          "proposal",
+          "verification"
+        ],
+        "type": "object"
+      },
+      "name": "proposal.decide",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/proposal-decide",
+      "stable_ref": "sg:operation/proposal-decide"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Promote only an independently verified and accepted proposal.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "governance_decision": {
+            "type": "object"
+          },
+          "proposal": {
+            "type": "object"
+          },
+          "registry": {
+            "type": "object"
+          },
+          "target_stable_ref": {
+            "type": "string"
+          },
+          "verification": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "governance_decision",
+          "proposal",
+          "target_stable_ref",
+          "verification"
+        ],
+        "type": "object"
+      },
+      "name": "proposal.promote",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/proposal-promote",
+      "stable_ref": "sg:operation/proposal-promote"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Create one immutable Task intent and required-result record.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "intent": {
+            "type": "object"
+          },
+          "required_result": {
+            "type": "object"
+          },
+          "stable_ref": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "intent",
+          "required_result",
+          "stable_ref"
+        ],
+        "type": "object"
+      },
+      "name": "task.create",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/task-create",
+      "stable_ref": "sg:operation/task-create"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Start one immutable Run attempt bound to a Task.",
+      "effect_class": "LOCAL",
+      "idempotent": false,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "input": {
+            "type": "object"
+          },
+          "stable_ref": {
+            "type": "string"
+          },
+          "task": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "stable_ref",
+          "task"
+        ],
+        "type": "object"
+      },
+      "name": "run.start",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/run-start",
+      "stable_ref": "sg:operation/run-start"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Record an external effect attempt and its durable connector receipt, if any.",
+      "effect_class": "EXTERNAL",
+      "idempotent": false,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "connector_receipt": {
+            "type": "string"
+          },
+          "effect_class": {
+            "type": "string"
+          },
+          "idempotency_key": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "stable_ref": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "effect_class",
+          "stable_ref"
+        ],
+        "type": "object"
+      },
+      "name": "effect.record",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/effect-record",
+      "stable_ref": "sg:operation/effect-record"
+    },
+    {
+      "adapters": [
+        "internal"
+      ],
+      "description": "Reconcile an uncertain effect from explicit connector observations.",
+      "effect_class": "LOCAL",
+      "idempotent": true,
+      "read_only": false,
+      "input_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "effect": {
+            "type": "object"
+          },
+          "observations": {
+            "type": "array"
+          },
+          "strategy": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "effect",
+          "observations"
+        ],
+        "type": "object"
+      },
+      "name": "effect.reconcile",
+      "output_schema": {
+        "type": "object"
+      },
+      "record_kind": "operation",
+      "required_capability": "sg:capability/effect-reconcile",
+      "stable_ref": "sg:operation/effect-reconcile"
+    }
+  ],
+  "schema_version": "1.0"
+}

--- a/consumer-reference/agent-native/schema/agent-native.schema.json
+++ b/consumer-reference/agent-native/schema/agent-native.schema.json
@@ -1,0 +1,848 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/agent-native.schema.json",
+  "title": "StyleGallery agent-native closed record family",
+  "description": "Closed machine-readable contracts for immutable identity, epistemic records, operations, execution, protocol bindings, retrieval, and governed learning. Canonical hashes and cross-record joins are checked by the runtime kernel in addition to this structural schema.",
+  "$defs": {
+    "stableRef": { "type": "string", "pattern": "^sg:[a-z0-9]+(?:-[a-z0-9]+)*/[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "versionId": { "type": "string", "pattern": "^sg:[a-z0-9]+(?:-[a-z0-9]+)*/[a-z0-9]+(?:-[a-z0-9]+)*@sha256:[a-f0-9]{64}$" },
+    "hexDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "sha256Digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "nonEmpty": { "type": "string", "minLength": 1 },
+    "jsonValue": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "number" },
+        { "type": "string" },
+        { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+        { "type": "object", "additionalProperties": { "$ref": "#/$defs/jsonValue" } }
+      ]
+    },
+    "jsonObject": { "type": "object", "additionalProperties": { "$ref": "#/$defs/jsonValue" } },
+    "stableRefList": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/stableRef" } },
+    "versionIdList": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/versionId" } },
+    "recordIdentity": {
+      "type": "object",
+      "required": ["schema_version", "record_kind", "stable_ref", "version_id"],
+      "properties": {
+        "schema_version": { "const": "1.0" },
+        "record_kind": { "type": "string", "minLength": 1 },
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" }
+      }
+    },
+    "manifestEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stable_ref", "version_id", "content_sha256"],
+      "properties": {
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" },
+        "content_sha256": { "$ref": "#/$defs/hexDigest" }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "manifest_ref", "version_id", "entries", "sha256"],
+      "properties": {
+        "schema_version": { "const": "1.0" },
+        "manifest_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" },
+        "entries": { "type": "array", "minItems": 0, "items": { "$ref": "#/$defs/manifestEntry" } },
+        "sha256": { "$ref": "#/$defs/hexDigest" }
+      }
+    },
+    "artifactProjection": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "artifact_projection" },
+          "canonical_sha256": { "$ref": "#/$defs/hexDigest" },
+          "media_type": { "$ref": "#/$defs/nonEmpty" },
+          "repository_path": { "$ref": "#/$defs/nonEmpty" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "executableFixture": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "executable_fixture" },
+          "command": { "$ref": "#/$defs/nonEmpty" },
+          "expected": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "exit_code": { "type": "integer" },
+              "report_ok": { "type": "boolean" },
+              "stderr": { "type": "string" }
+            }
+          }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "profileProjection": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "profile_projection" },
+          "id": { "$ref": "#/$defs/nonEmpty" },
+          "title": { "$ref": "#/$defs/nonEmpty" },
+          "profile_kind": { "$ref": "#/$defs/nonEmpty" },
+          "maturity": { "$ref": "#/$defs/nonEmpty" },
+          "support_status": { "$ref": "#/$defs/nonEmpty" },
+          "example_only": { "type": "boolean" },
+          "source_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_refs": { "$ref": "#/$defs/stableRefList" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "agentDescription": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "agent_description" },
+          "name": { "$ref": "#/$defs/nonEmpty" },
+          "conformance_profile_ref": { "$ref": "#/$defs/stableRef" },
+          "protocol_surfaces": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "a2a": { "$ref": "#/$defs/nonEmpty" },
+              "ag_ui": { "$ref": "#/$defs/nonEmpty" },
+              "cli": { "$ref": "#/$defs/nonEmpty" },
+              "mcp": { "$ref": "#/$defs/nonEmpty" }
+            }
+          }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "validator": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "validator" },
+          "name": { "$ref": "#/$defs/nonEmpty" },
+          "validator_version": { "$ref": "#/$defs/nonEmpty" },
+          "verification_scope": { "$ref": "#/$defs/nonEmpty" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "executionReceipt": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "execution_receipt" },
+          "command": { "$ref": "#/$defs/nonEmpty" },
+          "fixture_ref": { "$ref": "#/$defs/stableRef" },
+          "fixture_record_ref": { "$ref": "#/$defs/stableRef" },
+          "fixture_version_id": { "$ref": "#/$defs/versionId" },
+          "result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["exit_code", "report_ok", "stderr_sha256"],
+            "properties": {
+              "exit_code": { "type": "integer" },
+              "report_ok": { "type": "boolean" },
+              "stderr_sha256": { "$ref": "#/$defs/hexDigest" }
+            }
+          },
+          "result_sha256": { "$ref": "#/$defs/sha256Digest" },
+          "verification": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["method", "status", "verifier_ref", "verifier_version"],
+            "properties": {
+              "method": { "$ref": "#/$defs/nonEmpty" },
+              "status": { "$ref": "#/$defs/nonEmpty" },
+              "verifier_ref": { "$ref": "#/$defs/stableRef" },
+              "verifier_version": { "$ref": "#/$defs/nonEmpty" }
+            }
+          }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "conformanceProfile": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "conformance_profile" },
+          "profile_id": { "$ref": "#/$defs/nonEmpty" },
+          "conformance_level": { "$ref": "#/$defs/nonEmpty" },
+          "claim_refs": { "$ref": "#/$defs/stableRefList" },
+          "operation_refs": { "$ref": "#/$defs/stableRefList" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "claim": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "claim" },
+          "statement": { "$ref": "#/$defs/nonEmpty" },
+          "title": { "$ref": "#/$defs/nonEmpty" },
+          "description": { "type": "string" },
+          "scope": { "$ref": "#/$defs/jsonValue" },
+          "subject": { "$ref": "#/$defs/jsonValue" },
+          "subject_ref": { "$ref": "#/$defs/stableRef" },
+          "actor": { "$ref": "#/$defs/nonEmpty" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "evidence_refs": { "$ref": "#/$defs/stableRefList" },
+          "validation_refs": { "$ref": "#/$defs/stableRefList" },
+          "governance_refs": { "$ref": "#/$defs/stableRefList" },
+          "policy_refs": { "$ref": "#/$defs/stableRefList" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "status": { "$ref": "#/$defs/nonEmpty" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "evidenceLink": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "evidence_link" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "source_ref": { "$ref": "#/$defs/stableRef" },
+          "source_version": { "$ref": "#/$defs/versionId" },
+          "selector": { "$ref": "#/$defs/jsonValue" },
+          "independence_group": { "$ref": "#/$defs/nonEmpty" },
+          "polarity": { "enum": ["SUPPORT", "REFUTE", "SUPPORTED", "REFUTED"] },
+          "actor": { "$ref": "#/$defs/nonEmpty" },
+          "method": { "$ref": "#/$defs/nonEmpty" },
+          "observed_at": { "type": "string", "format": "date-time" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "attestation": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "attestation" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "polarity": { "enum": ["SUPPORT", "REFUTE", "SUPPORTED", "REFUTED"] },
+          "attestor": { "$ref": "#/$defs/nonEmpty" },
+          "actor": { "$ref": "#/$defs/nonEmpty" },
+          "method": { "$ref": "#/$defs/nonEmpty" },
+          "statement": { "$ref": "#/$defs/nonEmpty" },
+          "independence_group": { "$ref": "#/$defs/nonEmpty" },
+          "observed_at": { "type": "string", "format": "date-time" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "validationReport": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "validation_report" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "validator_ref": { "$ref": "#/$defs/stableRef" },
+          "validator": { "$ref": "#/$defs/nonEmpty" },
+          "validator_version": { "$ref": "#/$defs/nonEmpty" },
+          "status": { "enum": ["PASS", "PASSED", "FAIL", "FAILED", "UNKNOWN"] },
+          "suite": { "$ref": "#/$defs/nonEmpty" },
+          "inputs": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+          "findings": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+          "result": { "$ref": "#/$defs/jsonValue" },
+          "evaluated_at": { "type": "string", "format": "date-time" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "governanceDecision": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "governance_decision" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "governor_ref": { "$ref": "#/$defs/stableRef" },
+          "actor": { "$ref": "#/$defs/nonEmpty" },
+          "decision": { "enum": ["ACCEPT", "ACCEPTED", "APPROVE", "APPROVED", "REJECT", "REJECTED", "DENY", "DENIED", "DEFER", "DEFERRED"] },
+          "status": { "$ref": "#/$defs/nonEmpty" },
+          "scope": { "$ref": "#/$defs/jsonValue" },
+          "policy_version": { "$ref": "#/$defs/nonEmpty" },
+          "proposal_ref": { "$ref": "#/$defs/stableRef" },
+          "proposal_version_id": { "$ref": "#/$defs/versionId" },
+          "verification_ref": { "$ref": "#/$defs/stableRef" },
+          "verification_version_id": { "$ref": "#/$defs/versionId" },
+          "decided_at": { "type": "string", "format": "date-time" },
+          "reason": { "type": "string" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "policyDisposition": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "policy_disposition" },
+          "claim_ref": { "$ref": "#/$defs/stableRef" },
+          "claim_version": { "$ref": "#/$defs/versionId" },
+          "policy_version": { "$ref": "#/$defs/nonEmpty" },
+          "disposition": { "$ref": "#/$defs/nonEmpty" },
+          "subject": { "$ref": "#/$defs/nonEmpty" },
+          "subject_ref": { "$ref": "#/$defs/stableRef" },
+          "task_ref": { "$ref": "#/$defs/stableRef" },
+          "actor_ref": { "$ref": "#/$defs/stableRef" },
+          "scope": { "$ref": "#/$defs/jsonValue" },
+          "expires_at": { "type": "string", "format": "date-time" },
+          "reason": { "type": "string" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "evidenceAggregation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "evidence_state", "support_count", "refute_count", "support_groups", "refute_groups", "evidence_links"],
+      "properties": {
+        "claim_ref": { "$ref": "#/$defs/stableRef" },
+        "claim_version": { "$ref": "#/$defs/versionId" },
+        "state": { "enum": ["SUPPORTED", "REFUTED", "BOTH", "NEITHER"] },
+        "evidence_state": { "enum": ["SUPPORTED", "REFUTED", "BOTH", "NEITHER"] },
+        "support_count": { "type": "integer", "minimum": 0 },
+        "refute_count": { "type": "integer", "minimum": 0 },
+        "support_groups": { "type": "array", "items": { "type": "string" } },
+        "refute_groups": { "type": "array", "items": { "type": "string" } },
+        "evidence_links": { "type": "array", "items": { "$ref": "#/$defs/evidenceLink" } }
+      }
+    },
+    "operationSpec": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "operation" },
+          "name": { "$ref": "#/$defs/nonEmpty" },
+          "operation": { "$ref": "#/$defs/nonEmpty" },
+          "description": { "type": "string" },
+          "adapters": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/nonEmpty" } },
+          "effect_class": { "enum": ["NONE", "LOCAL", "EXTERNAL"] },
+          "idempotent": { "type": "boolean" },
+          "read_only": { "type": "boolean" },
+          "required_capability": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+          "input_schema": { "$ref": "#/$defs/jsonObject" },
+          "output_schema": { "$ref": "#/$defs/jsonObject" },
+          "preconditions": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+          "retry": { "$ref": "#/$defs/jsonValue" },
+          "reconcile": { "$ref": "#/$defs/jsonValue" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "capabilityGrant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject", "capability"],
+      "properties": {
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" },
+        "subject": { "$ref": "#/$defs/nonEmpty" },
+        "capability": { "$ref": "#/$defs/nonEmpty" },
+        "operations": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" }, "uniqueItems": true },
+        "operation": { "$ref": "#/$defs/nonEmpty" },
+        "resource_scope": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" }, "uniqueItems": true },
+        "resources": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" }, "uniqueItems": true },
+        "purpose": { "type": "string" },
+        "delegation_chain": { "type": "array", "items": { "$ref": "#/$defs/stableRef" } },
+        "revocation_ref": { "$ref": "#/$defs/stableRef" },
+        "expires_at": { "type": "string", "format": "date-time" },
+        "used": { "type": "integer", "minimum": 0 },
+        "used_calls": { "type": "integer", "minimum": 0 },
+        "max_calls": { "type": "integer", "minimum": 0 },
+        "limits": { "$ref": "#/$defs/jsonObject" }
+      }
+    },
+    "policyDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "capability", "evaluated_at", "operation", "reason", "resource", "subject"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "capability": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+        "evaluated_at": { "$ref": "#/$defs/nonEmpty" },
+        "operation": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+        "reason": { "$ref": "#/$defs/nonEmpty" },
+        "resource": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+        "subject": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] }
+      }
+    },
+    "authorizationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "decision", "policy_decision", "failures"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "decision": { "$ref": "#/$defs/policyDecision" },
+        "policy_decision": { "$ref": "#/$defs/policyDecision" },
+        "failures": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "task": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "task" },
+          "task_id": { "$ref": "#/$defs/stableRef" },
+          "intent": { "$ref": "#/$defs/jsonObject" },
+          "required_result": { "$ref": "#/$defs/jsonObject" },
+          "state": { "enum": ["SUBMITTED", "RUNNING", "COMPLETED", "FAILED", "CANCELED", "REJECTED", "AUTH_REQUIRED", "UNKNOWN"] },
+          "operation": { "$ref": "#/$defs/nonEmpty" },
+          "parent_task_id": { "$ref": "#/$defs/stableRef" },
+          "context_ref": { "$ref": "#/$defs/stableRef" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "run": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "run" },
+          "run_id": { "$ref": "#/$defs/stableRef" },
+          "task_id": { "$ref": "#/$defs/stableRef" },
+          "input": { "$ref": "#/$defs/jsonObject" },
+          "state": { "enum": ["RUNNING", "COMPLETED", "FAILED", "CANCELED", "REJECTED", "AUTH_REQUIRED", "UNKNOWN"] },
+          "attempt": { "type": "integer", "minimum": 0 },
+          "started_at": { "type": "string", "format": "date-time" },
+          "finished_at": { "type": "string", "format": "date-time" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "effect": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "effect" },
+          "effect_id": { "$ref": "#/$defs/stableRef" },
+          "effect_class": { "enum": ["NONE", "LOCAL", "EXTERNAL"] },
+          "task_id": { "oneOf": [{ "$ref": "#/$defs/stableRef" }, { "type": "null" }] },
+          "run_id": { "oneOf": [{ "$ref": "#/$defs/stableRef" }, { "type": "null" }] },
+          "task": { "$ref": "#/$defs/jsonObject" },
+          "run": { "$ref": "#/$defs/jsonObject" },
+          "attempt": { "$ref": "#/$defs/jsonValue" },
+          "idempotency_key": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+          "connector_receipt": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+          "state": { "enum": ["PLANNED", "COMMITTED", "FAILED", "UNCERTAIN", "COMPENSATED"] },
+          "observation_refs": { "$ref": "#/$defs/stableRefList" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "invocationReceipt": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "invocation_receipt" },
+          "input_digest": { "$ref": "#/$defs/sha256Digest" },
+          "output_digest": { "$ref": "#/$defs/sha256Digest" },
+          "operation": { "oneOf": [{ "$ref": "#/$defs/nonEmpty" }, { "type": "null" }] },
+          "task_id": { "oneOf": [{ "$ref": "#/$defs/stableRef" }, { "type": "null" }] },
+          "run_id": { "oneOf": [{ "$ref": "#/$defs/stableRef" }, { "type": "null" }] },
+          "effect_ids": { "$ref": "#/$defs/stableRefList" },
+          "effects": { "type": "array", "items": { "$ref": "#/$defs/effect" } },
+          "causal_parents": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" }, "uniqueItems": true },
+          "policy_decision": { "oneOf": [{ "$ref": "#/$defs/policyDecision" }, { "type": "null" }] }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_id", "parents"],
+      "properties": {
+        "event_id": { "$ref": "#/$defs/nonEmpty" },
+        "parents": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/nonEmpty" } },
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "type": { "$ref": "#/$defs/nonEmpty" },
+        "event_type": { "$ref": "#/$defs/nonEmpty" },
+        "task_id": { "$ref": "#/$defs/stableRef" },
+        "run_id": { "$ref": "#/$defs/stableRef" },
+        "effect_id": { "$ref": "#/$defs/stableRef" },
+        "taskId": { "$ref": "#/$defs/nonEmpty" },
+        "runId": { "$ref": "#/$defs/nonEmpty" },
+        "effectState": { "$ref": "#/$defs/nonEmpty" },
+        "payload": { "$ref": "#/$defs/jsonValue" },
+        "data": { "$ref": "#/$defs/jsonValue" },
+        "metadata": { "$ref": "#/$defs/jsonObject" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "protocolBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["protocol"],
+      "anyOf": [
+        { "required": ["protocolBindingId"] },
+        { "required": ["bindingId"] },
+        { "required": ["binding_id"] }
+      ],
+      "properties": {
+        "protocol": { "$ref": "#/$defs/nonEmpty" },
+        "protocolBindingId": { "$ref": "#/$defs/nonEmpty" },
+        "bindingId": { "$ref": "#/$defs/nonEmpty" },
+        "binding_id": { "$ref": "#/$defs/nonEmpty" },
+        "protocolTaskId": { "$ref": "#/$defs/nonEmpty" },
+        "protocolContextId": { "$ref": "#/$defs/nonEmpty" },
+        "protocolRunId": { "$ref": "#/$defs/nonEmpty" },
+        "taskId": { "$ref": "#/$defs/nonEmpty" },
+        "runId": { "$ref": "#/$defs/nonEmpty" },
+        "domainTaskId": { "$ref": "#/$defs/nonEmpty" },
+        "domainRunId": { "$ref": "#/$defs/nonEmpty" },
+        "threadId": { "$ref": "#/$defs/nonEmpty" },
+        "protocol_task_id": { "$ref": "#/$defs/nonEmpty" },
+        "protocol_context_id": { "$ref": "#/$defs/nonEmpty" },
+        "protocol_binding_id": { "$ref": "#/$defs/nonEmpty" }
+      }
+    },
+    "a2aTask": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifacts", "contextId", "history", "id", "kind", "metadata", "protocolBinding", "status"],
+      "properties": {
+        "artifacts": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+        "contextId": { "$ref": "#/$defs/nonEmpty" },
+        "history": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+        "id": { "$ref": "#/$defs/nonEmpty" },
+        "kind": { "const": "task" },
+        "metadata": { "$ref": "#/$defs/jsonObject" },
+        "protocolBinding": { "$ref": "#/$defs/protocolBinding" },
+        "status": { "$ref": "#/$defs/jsonObject" }
+      }
+    },
+    "aguiEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "runId"],
+      "properties": {
+        "type": { "$ref": "#/$defs/nonEmpty" },
+        "runId": { "$ref": "#/$defs/nonEmpty" },
+        "threadId": { "$ref": "#/$defs/nonEmpty" },
+        "messageId": { "$ref": "#/$defs/nonEmpty" },
+        "role": { "$ref": "#/$defs/nonEmpty" },
+        "delta": { "type": "string" },
+        "toolCallId": { "$ref": "#/$defs/nonEmpty" },
+        "toolCallName": { "$ref": "#/$defs/nonEmpty" },
+        "input": { "$ref": "#/$defs/jsonValue" },
+        "metadata": { "$ref": "#/$defs/jsonObject" },
+        "snapshot": { "$ref": "#/$defs/jsonValue" },
+        "result": { "$ref": "#/$defs/jsonValue" },
+        "message": { "$ref": "#/$defs/nonEmpty" }
+      }
+    },
+    "aguiProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "events", "protocolBinding", "protocolIds"],
+      "properties": {
+        "ok": { "const": true },
+        "events": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/aguiEvent" } },
+        "protocolBinding": { "$ref": "#/$defs/protocolBinding" },
+        "protocolIds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["threadId", "taskId", "runId"],
+          "properties": {
+            "threadId": { "$ref": "#/$defs/nonEmpty" },
+            "taskId": { "$ref": "#/$defs/nonEmpty" },
+            "runId": { "$ref": "#/$defs/nonEmpty" }
+          }
+        }
+      }
+    },
+    "agentCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capabilities", "defaultInputModes", "defaultOutputModes", "description", "name", "protocolVersion", "skills", "url", "version"],
+      "properties": {
+        "capabilities": { "$ref": "#/$defs/jsonObject" },
+        "defaultInputModes": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" } },
+        "defaultOutputModes": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" } },
+        "description": { "$ref": "#/$defs/nonEmpty" },
+        "name": { "$ref": "#/$defs/nonEmpty" },
+        "protocolVersion": { "$ref": "#/$defs/nonEmpty" },
+        "skills": { "type": "array", "items": { "$ref": "#/$defs/jsonObject" } },
+        "supportsAuthenticatedExtendedCard": { "type": "boolean" },
+        "url": { "$ref": "#/$defs/nonEmpty" },
+        "version": { "$ref": "#/$defs/nonEmpty" }
+      }
+    },
+    "viewSnapshot": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "view_snapshot" },
+          "snapshot_ref": { "$ref": "#/$defs/stableRef" },
+          "version_id": { "$ref": "#/$defs/versionId" },
+          "sha256": { "$ref": "#/$defs/sha256Digest" },
+          "cache_key": { "$ref": "#/$defs/nonEmpty" },
+          "as_of": { "type": "string" },
+          "builder_version": { "$ref": "#/$defs/nonEmpty" },
+          "heads": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/nonEmpty" } },
+          "members": { "type": "array", "items": { "$ref": "#/$defs/jsonObject" } },
+          "policy": { "$ref": "#/$defs/jsonValue" },
+          "truncated": { "type": "boolean" },
+          "transaction_at": { "type": "string" },
+          "valid_at": { "type": "string" },
+          "view_spec": { "$ref": "#/$defs/jsonObject" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "memberReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [{ "required": ["stable_ref"] }, { "required": ["version_id"] }, { "required": ["content_sha256"] }],
+      "properties": {
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" },
+        "content_sha256": { "$ref": "#/$defs/hexDigest" }
+      }
+    },
+    "contextPackage": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "context_package" },
+          "sha256": { "$ref": "#/$defs/sha256Digest" },
+          "cache_key": { "$ref": "#/$defs/nonEmpty" },
+          "budget": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tokens", "used_tokens", "truncated"],
+            "properties": {
+              "tokens": { "type": "integer", "minimum": 0 },
+              "used_tokens": { "type": "integer", "minimum": 0 },
+              "truncated": { "type": "boolean" }
+            }
+          },
+          "members": { "type": "array", "items": { "$ref": "#/$defs/jsonObject" } },
+          "member_refs": { "type": "array", "items": { "$ref": "#/$defs/memberReference" } },
+          "member_manifest": { "type": "array", "items": { "$ref": "#/$defs/memberReference" } },
+          "policy": { "$ref": "#/$defs/jsonValue" },
+          "query": { "type": "string" },
+          "query_class": { "$ref": "#/$defs/nonEmpty" },
+          "retriever": { "$ref": "#/$defs/nonEmpty" },
+          "selectors": { "$ref": "#/$defs/jsonValue" },
+          "snapshot": { "$ref": "#/$defs/jsonValue" },
+          "snapshot_ref": { "$ref": "#/$defs/stableRef" },
+          "snapshot_version_id": { "$ref": "#/$defs/versionId" },
+          "assembly_receipt": { "$ref": "#/$defs/jsonValue" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "learningProposal": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "learning_proposal" },
+          "proposal_id": { "$ref": "#/$defs/stableRef" },
+          "claim": { "$ref": "#/$defs/jsonObject" },
+          "changes": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/jsonValue" } },
+          "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/jsonValue" } },
+          "proposer": { "$ref": "#/$defs/nonEmpty" },
+          "source_task": { "$ref": "#/$defs/jsonValue" },
+          "status": { "const": "PROPOSED" },
+          "validation": { "$ref": "#/$defs/jsonObject" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "learningVerification": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "learning_verification" },
+          "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/jsonValue" } },
+          "independent": { "const": true },
+          "independent_of": { "$ref": "#/$defs/nonEmpty" },
+          "proposal_ref": { "$ref": "#/$defs/stableRef" },
+          "proposal_version_id": { "$ref": "#/$defs/versionId" },
+          "validation": { "$ref": "#/$defs/jsonObject" },
+          "verified": { "const": true },
+          "verifier": { "$ref": "#/$defs/nonEmpty" },
+          "verifier_actor": { "$ref": "#/$defs/nonEmpty" },
+          "status": { "const": "VERIFIED" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "governedVersion": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/recordIdentity" },
+        { "type": "object", "properties": {
+          "record_kind": { "const": "governed_version" },
+          "changes": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+          "claim": { "$ref": "#/$defs/jsonObject" },
+          "evidence": { "type": "array", "items": { "$ref": "#/$defs/jsonValue" } },
+          "proposal_ref": { "$ref": "#/$defs/stableRef" },
+          "proposal_version_id": { "$ref": "#/$defs/versionId" },
+          "verification_version_id": { "$ref": "#/$defs/versionId" },
+          "governance_decision_version_id": { "$ref": "#/$defs/versionId" }
+        } }
+      ],
+      "unevaluatedProperties": false
+    },
+    "promotionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "record_kind", "outcome", "proposal_ref", "stable_ref", "version_id"],
+      "properties": {
+        "schema_version": { "const": "1.0" },
+        "record_kind": { "const": "promotion_receipt" },
+        "outcome": { "const": "PROMOTED" },
+        "proposal_ref": { "$ref": "#/$defs/stableRef" },
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" },
+        "receipt_id": { "$ref": "#/$defs/versionId" },
+        "governed_version_id": { "$ref": "#/$defs/versionId" },
+        "governance_decision_version_id": { "$ref": "#/$defs/versionId" },
+        "proposal_version_id": { "$ref": "#/$defs/versionId" },
+        "verification_version_id": { "$ref": "#/$defs/versionId" }
+      }
+    },
+    "operationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapters", "effect_class", "idempotent", "name", "stable_ref", "version_id"],
+      "properties": {
+        "adapters": { "type": "array", "items": { "$ref": "#/$defs/nonEmpty" } },
+        "effect_class": { "enum": ["NONE", "LOCAL", "EXTERNAL"] },
+        "idempotent": { "type": "boolean" },
+        "read_only": { "type": "boolean" },
+        "name": { "$ref": "#/$defs/nonEmpty" },
+        "stable_ref": { "$ref": "#/$defs/stableRef" },
+        "version_id": { "$ref": "#/$defs/versionId" }
+      }
+    },
+    "selfDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "conformance", "manifest", "operation_digest", "operations", "protocol_surfaces", "schema_version"],
+      "properties": {
+        "agent": { "$ref": "#/$defs/agentDescription" },
+        "conformance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["claims", "profile", "status"],
+          "properties": {
+            "claims": { "type": "array", "items": { "$ref": "#/$defs/jsonObject" } },
+            "profile": { "$ref": "#/$defs/conformanceProfile" },
+            "status": { "$ref": "#/$defs/nonEmpty" }
+          }
+        },
+        "manifest": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["entry_count", "manifest_ref", "sha256", "version_id"],
+          "properties": {
+            "entry_count": { "type": "integer", "minimum": 0 },
+            "manifest_ref": { "$ref": "#/$defs/stableRef" },
+            "sha256": { "$ref": "#/$defs/hexDigest" },
+            "version_id": { "$ref": "#/$defs/versionId" }
+          }
+        },
+        "operation_digest": { "$ref": "#/$defs/sha256Digest" },
+        "operations": { "type": "array", "items": { "$ref": "#/$defs/operationSummary" } },
+        "protocol_surfaces": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["a2a", "ag_ui", "cli", "mcp"],
+          "properties": {
+            "a2a": { "$ref": "#/$defs/jsonObject" },
+            "ag_ui": { "$ref": "#/$defs/jsonObject" },
+            "cli": { "$ref": "#/$defs/jsonObject" },
+            "mcp": { "$ref": "#/$defs/jsonObject" }
+          }
+        },
+        "schema_version": { "const": "1.0" }
+      }
+    },
+    "record": {
+      "oneOf": [
+        { "$ref": "#/$defs/artifactProjection" },
+        { "$ref": "#/$defs/executableFixture" },
+        { "$ref": "#/$defs/profileProjection" },
+        { "$ref": "#/$defs/agentDescription" },
+        { "$ref": "#/$defs/validator" },
+        { "$ref": "#/$defs/executionReceipt" },
+        { "$ref": "#/$defs/conformanceProfile" },
+        { "$ref": "#/$defs/claim" },
+        { "$ref": "#/$defs/evidenceLink" },
+        { "$ref": "#/$defs/attestation" },
+        { "$ref": "#/$defs/validationReport" },
+        { "$ref": "#/$defs/governanceDecision" },
+        { "$ref": "#/$defs/policyDisposition" },
+        { "$ref": "#/$defs/operationSpec" },
+        { "$ref": "#/$defs/task" },
+        { "$ref": "#/$defs/run" },
+        { "$ref": "#/$defs/effect" },
+        { "$ref": "#/$defs/invocationReceipt" },
+        { "$ref": "#/$defs/viewSnapshot" },
+        { "$ref": "#/$defs/contextPackage" },
+        { "$ref": "#/$defs/learningProposal" },
+        { "$ref": "#/$defs/learningVerification" },
+        { "$ref": "#/$defs/governedVersion" }
+      ]
+    },
+    "root": {
+      "oneOf": [
+        { "$ref": "#/$defs/manifest" },
+        { "$ref": "#/$defs/record" },
+        { "$ref": "#/$defs/evidenceAggregation" },
+        { "$ref": "#/$defs/authorizationResult" },
+        { "$ref": "#/$defs/capabilityGrant" },
+        { "$ref": "#/$defs/event" },
+        { "$ref": "#/$defs/protocolBinding" },
+        { "$ref": "#/$defs/agentCard" },
+        { "$ref": "#/$defs/a2aTask" },
+        { "$ref": "#/$defs/aguiEvent" },
+        { "$ref": "#/$defs/aguiProjection" },
+        { "$ref": "#/$defs/selfDescription" },
+        { "$ref": "#/$defs/promotionReceipt" }
+      ]
+    }
+  },
+  "$ref": "#/$defs/root"
+}

--- a/consumer-reference/agent-native/schema/epistemic.schema.json
+++ b/consumer-reference/agent-native/schema/epistemic.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/epistemic.schema.json",
+  "title": "StyleGallery claim, evidence, validation, and governance records",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/claim" },
+    { "$ref": "agent-native.schema.json#/$defs/evidenceLink" },
+    { "$ref": "agent-native.schema.json#/$defs/attestation" },
+    { "$ref": "agent-native.schema.json#/$defs/validationReport" },
+    { "$ref": "agent-native.schema.json#/$defs/governanceDecision" },
+    { "$ref": "agent-native.schema.json#/$defs/policyDisposition" },
+    { "$ref": "agent-native.schema.json#/$defs/evidenceAggregation" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/execution.schema.json
+++ b/consumer-reference/agent-native/schema/execution.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/execution.schema.json",
+  "title": "StyleGallery Task, Run, effect, receipt, and causal event records",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/task" },
+    { "$ref": "agent-native.schema.json#/$defs/run" },
+    { "$ref": "agent-native.schema.json#/$defs/effect" },
+    { "$ref": "agent-native.schema.json#/$defs/invocationReceipt" },
+    { "$ref": "agent-native.schema.json#/$defs/event" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/identity.schema.json
+++ b/consumer-reference/agent-native/schema/identity.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/identity.schema.json",
+  "title": "StyleGallery StableRef, VersionID, and immutable manifest",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/stableRef" },
+    { "$ref": "agent-native.schema.json#/$defs/versionId" },
+    { "$ref": "agent-native.schema.json#/$defs/manifest" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/learning.schema.json
+++ b/consumer-reference/agent-native/schema/learning.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/learning.schema.json",
+  "title": "StyleGallery governed learning artifacts",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/learningProposal" },
+    { "$ref": "agent-native.schema.json#/$defs/learningVerification" },
+    { "$ref": "agent-native.schema.json#/$defs/governedVersion" },
+    { "$ref": "agent-native.schema.json#/$defs/promotionReceipt" },
+    { "$ref": "agent-native.schema.json#/$defs/governanceDecision" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/manifest.schema.json
+++ b/consumer-reference/agent-native/schema/manifest.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/manifest.schema.json",
+  "title": "StyleGallery immutable manifest",
+  "$ref": "agent-native.schema.json#/$defs/manifest"
+}

--- a/consumer-reference/agent-native/schema/operation.schema.json
+++ b/consumer-reference/agent-native/schema/operation.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/operation.schema.json",
+  "title": "StyleGallery operation and capability records",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/operationSpec" },
+    { "$ref": "agent-native.schema.json#/$defs/capabilityGrant" },
+    { "$ref": "agent-native.schema.json#/$defs/policyDecision" },
+    { "$ref": "agent-native.schema.json#/$defs/authorizationResult" },
+    { "$ref": "agent-native.schema.json#/$defs/invocationReceipt" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/protocol-binding.schema.json
+++ b/consumer-reference/agent-native/schema/protocol-binding.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/protocol-binding.schema.json",
+  "title": "StyleGallery cross-protocol binding and A2A Agent Card",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/protocolBinding" },
+    { "$ref": "agent-native.schema.json#/$defs/agentCard" }
+  ]
+}

--- a/consumer-reference/agent-native/schema/retrieval.schema.json
+++ b/consumer-reference/agent-native/schema/retrieval.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylegallery.local/consumer-reference/agent-native/schema/retrieval.schema.json",
+  "title": "StyleGallery retrieval ViewSnapshot and ContextPackage",
+  "oneOf": [
+    { "$ref": "agent-native.schema.json#/$defs/viewSnapshot" },
+    { "$ref": "agent-native.schema.json#/$defs/contextPackage" },
+    { "$ref": "agent-native.schema.json#/$defs/memberReference" }
+  ]
+}

--- a/design-engineering/reference-profiles/governed-local/editorial/evidence/button.evidence.json
+++ b/design-engineering/reference-profiles/governed-local/editorial/evidence/button.evidence.json
@@ -17,44 +17,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-visual",
-      "recorded_at": "2026-07-14T06:33:48.519Z",
+      "recorded_at": "2026-07-23T01:54:39.067Z",
       "result": {
         "observed": "Recorded visual evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -98,14 +98,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -223,9 +223,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -239,9 +239,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-disabled-busy.dom.json",
-        "byte_length": 8290,
+        "byte_length": 8262,
         "media_type": "application/json",
-        "sha256": "sha256:ab25974eaf732f35b45f1f8f6640ae43aabaf82f4a1caca5eecedec90b95347c"
+        "sha256": "sha256:cfefb72a0680ffc81262257c3146292b2a46f26ffd3c2db28476209f2bae4050"
       },
       "channel": "dom",
       "environment": {
@@ -249,44 +249,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-dom",
-      "recorded_at": "2026-07-14T06:33:48.519Z",
+      "recorded_at": "2026-07-23T01:54:39.067Z",
       "result": {
         "observed": "Recorded dom evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -330,14 +330,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -455,9 +455,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -471,9 +471,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-disabled-busy.ax.json",
-        "byte_length": 8209,
+        "byte_length": 8181,
         "media_type": "application/json",
-        "sha256": "sha256:d0869084b405cde4f0343f07d88b66c1331e78dcc7e0d83093d32040896cd736"
+        "sha256": "sha256:943366a4031685ddf01d7c9dea38e495644caf9be5a2052e48e8251e7f7fcf48"
       },
       "channel": "ax",
       "environment": {
@@ -481,44 +481,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-ax",
-      "recorded_at": "2026-07-14T06:33:48.519Z",
+      "recorded_at": "2026-07-23T01:54:39.067Z",
       "result": {
         "observed": "Recorded ax evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -562,14 +562,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -687,9 +687,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -715,44 +715,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-visual",
-      "recorded_at": "2026-07-14T06:33:48.646Z",
+      "recorded_at": "2026-07-23T01:54:39.198Z",
       "result": {
         "observed": "Recorded visual evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -796,14 +796,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -921,9 +921,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -936,9 +936,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-focused.dom.json",
-        "byte_length": 8230,
+        "byte_length": 8202,
         "media_type": "application/json",
-        "sha256": "sha256:0bda7500dae5d94f823831548374c2d7444eaf8bd687fcaa592caeeaf763cd2b"
+        "sha256": "sha256:f1352d3d0ab66f4e8154d5dda4f93345f04daf1596b99593f3a727119c573ffc"
       },
       "channel": "dom",
       "environment": {
@@ -946,44 +946,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-dom",
-      "recorded_at": "2026-07-14T06:33:48.646Z",
+      "recorded_at": "2026-07-23T01:54:39.198Z",
       "result": {
         "observed": "Recorded dom evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1027,14 +1027,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1152,9 +1152,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1167,9 +1167,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-focused.ax.json",
-        "byte_length": 8150,
+        "byte_length": 8122,
         "media_type": "application/json",
-        "sha256": "sha256:64a6b20340c3812d06fcdff4f132df15227a3a893e4939eb61381ca12824defe"
+        "sha256": "sha256:71be8cf7db0b932bb95dea4b5c906e193074213779d2a0392ea1504c2127234e"
       },
       "channel": "ax",
       "environment": {
@@ -1177,44 +1177,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-ax",
-      "recorded_at": "2026-07-14T06:33:48.646Z",
+      "recorded_at": "2026-07-23T01:54:39.198Z",
       "result": {
         "observed": "Recorded ax evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1258,14 +1258,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1383,9 +1383,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1410,44 +1410,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-visual",
-      "recorded_at": "2026-07-14T06:33:48.756Z",
+      "recorded_at": "2026-07-23T01:54:39.315Z",
       "result": {
         "observed": "Recorded visual evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1491,14 +1491,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1616,9 +1616,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1633,9 +1633,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-loading-busy.dom.json",
-        "byte_length": 8276,
+        "byte_length": 8248,
         "media_type": "application/json",
-        "sha256": "sha256:d61c0b69ff4751ae958e4f7bab971d8767cd5dab9e832b601cc0828da9f6aa72"
+        "sha256": "sha256:02d8be8abaf5b57b60f3ab1ba39a341976666de36d37b50bdd180e4b62655c57"
       },
       "channel": "dom",
       "environment": {
@@ -1643,44 +1643,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-dom",
-      "recorded_at": "2026-07-14T06:33:48.756Z",
+      "recorded_at": "2026-07-23T01:54:39.315Z",
       "result": {
         "observed": "Recorded dom evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1724,14 +1724,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1849,9 +1849,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1866,9 +1866,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-action-loading-busy.ax.json",
-        "byte_length": 8176,
+        "byte_length": 8148,
         "media_type": "application/json",
-        "sha256": "sha256:146911dc4f509ac7333465f252f4205c2a7eb0de4d0a4dee70b30fe71e49cd80"
+        "sha256": "sha256:11340e6e40b7054415f08a14868c52a8b12960399ba47ad6ccb273759df7e9b3"
       },
       "channel": "ax",
       "environment": {
@@ -1876,44 +1876,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-ax",
-      "recorded_at": "2026-07-14T06:33:48.756Z",
+      "recorded_at": "2026-07-23T01:54:39.315Z",
       "result": {
         "observed": "Recorded ax evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1957,14 +1957,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2082,9 +2082,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2111,44 +2111,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-visual",
-      "recorded_at": "2026-07-14T06:33:48.879Z",
+      "recorded_at": "2026-07-23T01:54:39.459Z",
       "result": {
         "observed": "Recorded visual evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2192,14 +2192,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2317,9 +2317,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2335,9 +2335,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-disclosure-expanded-loading.dom.json",
-        "byte_length": 8333,
+        "byte_length": 8305,
         "media_type": "application/json",
-        "sha256": "sha256:649083cf7bd92df1baac83cd6e050a1e0e9ea8ea300a2edaa7ffb8dfb09f3cec"
+        "sha256": "sha256:dc5f61ae6ebbde13e2fe5a21b3a57ec4be7585cace318aea2fc26490507cbe0b"
       },
       "channel": "dom",
       "environment": {
@@ -2345,44 +2345,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-dom",
-      "recorded_at": "2026-07-14T06:33:48.879Z",
+      "recorded_at": "2026-07-23T01:54:39.459Z",
       "result": {
         "observed": "Recorded dom evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2426,14 +2426,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2551,9 +2551,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2569,9 +2569,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-disclosure-expanded-loading.ax.json",
-        "byte_length": 8214,
+        "byte_length": 8186,
         "media_type": "application/json",
-        "sha256": "sha256:a335914fea6d7933d4a68f84951a53e2679be43faeda67ea3f26338c27fa1ba2"
+        "sha256": "sha256:3ceb56827a68f27a10b7cbed1f7439567e24e0cd63704811a5bf074cfb2b92f6"
       },
       "channel": "ax",
       "environment": {
@@ -2579,44 +2579,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-ax",
-      "recorded_at": "2026-07-14T06:33:48.879Z",
+      "recorded_at": "2026-07-23T01:54:39.459Z",
       "result": {
         "observed": "Recorded ax evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2660,14 +2660,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2785,9 +2785,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2815,44 +2815,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-visual",
-      "recorded_at": "2026-07-14T06:33:49.004Z",
+      "recorded_at": "2026-07-23T01:54:39.574Z",
       "result": {
         "observed": "Recorded visual evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2896,14 +2896,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3021,9 +3021,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -3037,9 +3037,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-toggle-focused-pressed.dom.json",
-        "byte_length": 8270,
+        "byte_length": 8242,
         "media_type": "application/json",
-        "sha256": "sha256:bbc4bc195fc3a003c8c5126637e102e7e573a8f3568cc7a725c49d506802c2e6"
+        "sha256": "sha256:3d5b02169602d97cc6dc4421fc2cfc652817402d0bc9dc92f8b7c57c11eeddbd"
       },
       "channel": "dom",
       "environment": {
@@ -3047,44 +3047,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-dom",
-      "recorded_at": "2026-07-14T06:33:49.004Z",
+      "recorded_at": "2026-07-23T01:54:39.574Z",
       "result": {
         "observed": "Recorded dom evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -3128,14 +3128,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3253,9 +3253,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -3269,9 +3269,9 @@
     {
       "artifact": {
         "path": "runtime/editorial-toggle-focused-pressed.ax.json",
-        "byte_length": 8184,
+        "byte_length": 8156,
         "media_type": "application/json",
-        "sha256": "sha256:e0709f66f261a595827a43941a9b51a65c1789540c193c17a7dc0b92884ccdc1"
+        "sha256": "sha256:bc127d0f148dc4dce80cd1facf378a0fa03ac920ba0cab93249b4ed0eb3d4e8a"
       },
       "channel": "ax",
       "environment": {
@@ -3279,44 +3279,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-ax",
-      "recorded_at": "2026-07-14T06:33:49.004Z",
+      "recorded_at": "2026-07-23T01:54:39.574Z",
       "result": {
         "observed": "Recorded ax evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -3360,14 +3360,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3485,9 +3485,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",

--- a/design-engineering/reference-profiles/governed-local/terminal/evidence/button.evidence.json
+++ b/design-engineering/reference-profiles/governed-local/terminal/evidence/button.evidence.json
@@ -17,44 +17,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-visual",
-      "recorded_at": "2026-07-14T06:33:49.115Z",
+      "recorded_at": "2026-07-23T01:54:39.692Z",
       "result": {
         "observed": "Recorded visual evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -98,14 +98,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -223,9 +223,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -239,9 +239,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-disabled-busy.dom.json",
-        "byte_length": 8289,
+        "byte_length": 8261,
         "media_type": "application/json",
-        "sha256": "sha256:e775814ee40672cf5a86d312d6409a89ad24250ed04bdb3687a0c5bc4186e907"
+        "sha256": "sha256:20da4192469ddf588a13e528068dce9aaa305a61baa8794d2344c1da78911ead"
       },
       "channel": "dom",
       "environment": {
@@ -249,44 +249,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-dom",
-      "recorded_at": "2026-07-14T06:33:49.115Z",
+      "recorded_at": "2026-07-23T01:54:39.692Z",
       "result": {
         "observed": "Recorded dom evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -330,14 +330,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -455,9 +455,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -471,9 +471,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-disabled-busy.ax.json",
-        "byte_length": 8208,
+        "byte_length": 8180,
         "media_type": "application/json",
-        "sha256": "sha256:07da1033e729a695631458754b9f53d8671b0e4b511c74372bc6543e4f352b50"
+        "sha256": "sha256:997c457a660d4dd2edae13dca05adec6ba3459dd3e88abdb51fe793ebcad3d03"
       },
       "channel": "ax",
       "environment": {
@@ -481,44 +481,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-disabled-busy-ax",
-      "recorded_at": "2026-07-14T06:33:49.115Z",
+      "recorded_at": "2026-07-23T01:54:39.692Z",
       "result": {
         "observed": "Recorded ax evidence for action-disabled-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-disabled-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -562,14 +562,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -687,9 +687,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -715,44 +715,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-visual",
-      "recorded_at": "2026-07-14T06:33:49.228Z",
+      "recorded_at": "2026-07-23T01:54:39.815Z",
       "result": {
         "observed": "Recorded visual evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -796,14 +796,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -921,9 +921,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -936,9 +936,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-focused.dom.json",
-        "byte_length": 8229,
+        "byte_length": 8201,
         "media_type": "application/json",
-        "sha256": "sha256:f71be6585f1ca78794f3baf6742bd25839e4ea9d6a2809b644aa2e2a811d30ae"
+        "sha256": "sha256:b08486707a40e4bacd1e84ea65649f4987220ee060c2fedd230bc52534ff8a3a"
       },
       "channel": "dom",
       "environment": {
@@ -946,44 +946,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-dom",
-      "recorded_at": "2026-07-14T06:33:49.228Z",
+      "recorded_at": "2026-07-23T01:54:39.815Z",
       "result": {
         "observed": "Recorded dom evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1027,14 +1027,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1152,9 +1152,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1167,9 +1167,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-focused.ax.json",
-        "byte_length": 8153,
+        "byte_length": 8125,
         "media_type": "application/json",
-        "sha256": "sha256:0192632a1c95628b3515536a9e90606ee04e1d217031a8f1c5358a97cc32cc4f"
+        "sha256": "sha256:cbb4e19ce2efad824272c83ea6459c3c05a99e75a917068e5cb387d94dc46801"
       },
       "channel": "ax",
       "environment": {
@@ -1177,44 +1177,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-focused-ax",
-      "recorded_at": "2026-07-14T06:33:49.228Z",
+      "recorded_at": "2026-07-23T01:54:39.815Z",
       "result": {
         "observed": "Recorded ax evidence for action-focused; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-focused",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1258,14 +1258,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1383,9 +1383,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1410,44 +1410,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-visual",
-      "recorded_at": "2026-07-14T06:33:49.354Z",
+      "recorded_at": "2026-07-23T01:54:39.937Z",
       "result": {
         "observed": "Recorded visual evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1491,14 +1491,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1616,9 +1616,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1633,9 +1633,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-loading-busy.dom.json",
-        "byte_length": 8275,
+        "byte_length": 8247,
         "media_type": "application/json",
-        "sha256": "sha256:ca53cb29c53b267fc92cc68475fe4c2ea2c3dcccd31c1c6e858dc8a17198e358"
+        "sha256": "sha256:b8abb2b2e21067fd3172915a7d03e2db216692ea817941d8a3f7617e69a082d8"
       },
       "channel": "dom",
       "environment": {
@@ -1643,44 +1643,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-dom",
-      "recorded_at": "2026-07-14T06:33:49.354Z",
+      "recorded_at": "2026-07-23T01:54:39.937Z",
       "result": {
         "observed": "Recorded dom evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1724,14 +1724,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -1849,9 +1849,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -1866,9 +1866,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-action-loading-busy.ax.json",
-        "byte_length": 8180,
+        "byte_length": 8152,
         "media_type": "application/json",
-        "sha256": "sha256:2ff34baf906c25aae5984939ac89a1b78464755dbd0bd8f2aa8313ec5eb6b357"
+        "sha256": "sha256:dcb41ba6b9405cbfb08bbdee92bc8c201163f31f552c9b01c94ef5cc91bb2b54"
       },
       "channel": "ax",
       "environment": {
@@ -1876,44 +1876,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "action-loading-busy-ax",
-      "recorded_at": "2026-07-14T06:33:49.354Z",
+      "recorded_at": "2026-07-23T01:54:39.937Z",
       "result": {
         "observed": "Recorded ax evidence for action-loading-busy; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "action-loading-busy",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -1957,14 +1957,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2082,9 +2082,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2111,44 +2111,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-visual",
-      "recorded_at": "2026-07-14T06:33:49.484Z",
+      "recorded_at": "2026-07-23T01:54:40.086Z",
       "result": {
         "observed": "Recorded visual evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2192,14 +2192,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2317,9 +2317,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2335,9 +2335,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-disclosure-expanded-loading.dom.json",
-        "byte_length": 8332,
+        "byte_length": 8304,
         "media_type": "application/json",
-        "sha256": "sha256:1ddd7f1de3ad2c34d9e8d718c7b3128593a99e4207dce33ffb89f2fcc8f7d5b7"
+        "sha256": "sha256:14a4b7f7618ba5be65b144d6fca0d191be2760f8959993857101565876ff5c90"
       },
       "channel": "dom",
       "environment": {
@@ -2345,44 +2345,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-dom",
-      "recorded_at": "2026-07-14T06:33:49.484Z",
+      "recorded_at": "2026-07-23T01:54:40.086Z",
       "result": {
         "observed": "Recorded dom evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2426,14 +2426,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2551,9 +2551,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2569,9 +2569,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-disclosure-expanded-loading.ax.json",
-        "byte_length": 8215,
+        "byte_length": 8187,
         "media_type": "application/json",
-        "sha256": "sha256:33371b0445ae51fc297e51103a8fd04060cc35dfd4c6abc08675463fee675c3e"
+        "sha256": "sha256:ae237e7035e93dcb3d865e683d709e9702b344ee1050b24320e0873670691718"
       },
       "channel": "ax",
       "environment": {
@@ -2579,44 +2579,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "disclosure-expanded-loading-ax",
-      "recorded_at": "2026-07-14T06:33:49.484Z",
+      "recorded_at": "2026-07-23T01:54:40.086Z",
       "result": {
         "observed": "Recorded ax evidence for disclosure-expanded-loading; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "disclosure-expanded-loading",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2660,14 +2660,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -2785,9 +2785,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -2815,44 +2815,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-visual",
-      "recorded_at": "2026-07-14T06:33:49.592Z",
+      "recorded_at": "2026-07-23T01:54:40.213Z",
       "result": {
         "observed": "Recorded visual evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -2896,14 +2896,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3021,9 +3021,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -3037,9 +3037,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-toggle-focused-pressed.dom.json",
-        "byte_length": 8269,
+        "byte_length": 8241,
         "media_type": "application/json",
-        "sha256": "sha256:5d16f2f75dddd358a1f9d9839045ae3bc73d9d9d029b4f76af8ae42d3469bab4"
+        "sha256": "sha256:3041fccbca89fb3f3eeb944c7317247a69eb51db5e8c65885f612d366007c8a4"
       },
       "channel": "dom",
       "environment": {
@@ -3047,44 +3047,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-dom",
-      "recorded_at": "2026-07-14T06:33:49.592Z",
+      "recorded_at": "2026-07-23T01:54:40.213Z",
       "result": {
         "observed": "Recorded dom evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -3128,14 +3128,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3253,9 +3253,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",
@@ -3269,9 +3269,9 @@
     {
       "artifact": {
         "path": "runtime/terminal-toggle-focused-pressed.ax.json",
-        "byte_length": 8181,
+        "byte_length": 8153,
         "media_type": "application/json",
-        "sha256": "sha256:596da3c726e836ad0f5a09f4c456981bb76627110b7f806f7cafad34f60ac55c"
+        "sha256": "sha256:b634f8ee825ef3df5c694f5a755c4103205bbd9143f28ffbc3c8d0fbef11d161"
       },
       "channel": "ax",
       "environment": {
@@ -3279,44 +3279,44 @@
         "browser_revision": "chromium-1228",
         "container_image": "local-host:25.5.0",
         "kind": "browser",
-        "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-        "node": "v22.23.1",
+        "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+        "node": "v24.18.0",
         "platform": "darwin/arm64",
         "playwright": "1.61.0",
         "viewport": "1024x768"
       },
       "id": "toggle-focused-pressed-ax",
-      "recorded_at": "2026-07-14T06:33:49.592Z",
+      "recorded_at": "2026-07-23T01:54:40.213Z",
       "result": {
         "observed": "Recorded ax evidence for toggle-focused-pressed; this is not certification.",
         "status": "passed"
       },
       "run": {
         "attempt": 1,
-        "id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "repository": "changeroa/StyleGallery",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
         "source": "local"
       },
       "scenario_id": "toggle-focused-pressed",
       "session": {
         "attempt": 1,
-        "branch": "codex/roadmap-07-final-hardening",
+        "branch": "main",
         "environment": {
           "browser": "Google Chrome for Testing 149.0.7827.55",
           "browser_revision": "chromium-1228",
           "container_image": "local-host:25.5.0",
           "kind": "browser",
-          "lockfile_sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80",
-          "node": "v22.23.1",
+          "lockfile_sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed",
+          "node": "v24.18.0",
           "platform": "darwin/arm64",
           "playwright": "1.61.0",
           "viewport": "1024x768"
         },
-        "nonce": "e9a2d4be58843c97ed9b5090c70f70e6db82510f84d2545ccb09e3cc3d6d46eb",
-        "receipt_sha256": "sha256:8d691f1a8c15f6d974e68a18281c206574207f34028e955bd3488890433c0cb2",
-        "revision": "017b96e26be60bfffb410c1994ab2acfd09beaaa",
-        "session_id": "8e81d617-4087-4350-9100-6e03798d1ff8",
+        "nonce": "f7161dfe3172419bab305e6f468c84af54fbfb7c34b23f76d6022ed79792e0b6",
+        "receipt_sha256": "sha256:7685465e5dcc3a9e7942c9dae85d374823c65fdc9da2951aa989fc5a86f2381d",
+        "revision": "7825a0de8e9bd52577c1d82620ae208b7f05c2fd",
+        "session_id": "e613fa3e-1857-4da5-9909-4bf71b4276dd",
         "source": {
           "files": [
             {
@@ -3360,14 +3360,14 @@
               "sha256": "sha256:5fe9bf91ec1198441169dc1aa0773c9f4d278b2e345d111c453c34bd0c575d49"
             },
             {
-              "byte_length": 60458,
+              "byte_length": 89496,
               "path": "package-lock.json",
-              "sha256": "sha256:d3f737b3aee4dffe053129c197ecc38393cd45123f0986d068655df34177ce80"
+              "sha256": "sha256:7dbb44b9c8f840a4f9bc79add9eab73534763aab45179e3c24ed4eddc896e3ed"
             },
             {
-              "byte_length": 1625,
+              "byte_length": 2485,
               "path": "package.json",
-              "sha256": "sha256:0ce4b2d065b7b3ebdcf6ab818939bea8e1595b99515b00fbc72586b12a056146"
+              "sha256": "sha256:bc84918b0be6f4389fab733e269077f2ebff9d7140cb4ff9035d8406cb5bb7cb"
             },
             {
               "byte_length": 532,
@@ -3485,9 +3485,9 @@
               "sha256": "sha256:51c09abb671b615d075ba74b8578efc500fc000d1e39a62d9fc20a76a27a5a46"
             }
           ],
-          "sha256": "sha256:dfc234bdeae8e90ac33cc5724893b9235a0898c85d5aff7cea349da354e53406"
+          "sha256": "sha256:cce35d423426049f09649f4cad2e838f0b00e8d2abb923f0cf739598055d3815"
         },
-        "started_at": "2026-07-14T06:33:47.214Z"
+        "started_at": "2026-07-23T01:54:37.813Z"
       },
       "scope": {
         "component": "button",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,11 @@
     "": {
       "name": "stylegallery-validation",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
         "style-dictionary": "5.5.0"
+      },
+      "bin": {
+        "sg": "scripts/sg.mjs"
       },
       "devDependencies": {
         "@axe-core/playwright": "4.12.1",
@@ -68,6 +72,18 @@
         "path": "^0.12.7",
         "stream": "^0.0.3",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -480,6 +496,46 @@
         "tslib": "2"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
@@ -507,11 +563,23 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -528,7 +596,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -609,6 +676,43 @@
       ],
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -643,6 +747,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -737,6 +850,94 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -780,6 +981,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -792,6 +1002,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/es-define-property": {
@@ -824,6 +1049,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -833,18 +1073,99 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -856,6 +1177,27 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -870,6 +1212,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1038,6 +1398,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -1045,6 +1434,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.18"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -1072,6 +1477,24 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -1148,6 +1571,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -1181,12 +1610,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1218,6 +1667,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memfs": {
       "version": "4.64.0",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.64.0.tgz",
@@ -1247,6 +1705,43 @@
         "tslib": "2"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1269,6 +1764,30 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1328,6 +1847,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -1336,6 +1885,15 @@
       "dependencies": {
         "process": "^0.11.1",
         "util": "^0.10.3"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
@@ -1352,6 +1910,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-unified": {
@@ -1373,6 +1941,15 @@
       "license": "MIT",
       "dependencies": {
         "inherits": "2.0.3"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -1440,6 +2017,19 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1462,14 +2052,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safe-buffer": {
@@ -1509,6 +2142,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -1524,6 +2208,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -1598,6 +2309,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stream": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.3.tgz",
@@ -1665,6 +2385,15 @@
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-dump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
@@ -1686,6 +2415,46 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/url": {
       "version": "0.11.4",
@@ -1713,6 +2482,30 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -1732,6 +2525,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">=22"
   },
+  "bin": {
+    "sg": "scripts/sg.mjs"
+  },
   "scripts": {
     "audit:evidence": "node scripts/audit-evidence-freshness.mjs",
     "build": "node scripts/build-reference-artifacts.mjs --adapter style-dictionary --fail-on-warning --json",
@@ -15,6 +18,9 @@
     "test:component-state:runtime": "playwright test tests/component-state-evidence.spec.mjs --project=chromium",
     "test:component-state:runtime-negative": "node scripts/test-component-state-sentinel.mjs",
     "test:sentinel": "playwright test tests/consumer-reference-sentinels.spec.mjs --project=chromium",
+    "sg": "node scripts/sg.mjs",
+    "sg:mcp": "node scripts/sg-mcp.mjs",
+    "test:agent-native": "node scripts/test-agent-knowledge-kernel.mjs --json && node scripts/test-agent-execution-kernel.mjs --json && node scripts/test-agent-execution-safety.mjs --json && node scripts/test-agent-events.mjs --json && node scripts/test-agent-learning.mjs --json && node scripts/test-agent-native-schemas.mjs --json && node scripts/test-sg-cli.mjs --json && node scripts/test-agent-conformance-receipt.mjs --json && node scripts/test-agent-mcp.mjs --json && node scripts/test-agent-registry-mcp-integrity.mjs --json && node scripts/test-agent-registry-mutations.mjs --json && node scripts/test-agent-adapter-conformance.mjs --json && node scripts/test-agent-projections.mjs --json",
     "validate": "node scripts/validate-reference-artifacts.mjs --manifest consumer-reference/generated/manifest.json --json",
     "validate:component-state": "node scripts/validate-component-state.mjs --json && node scripts/generate-consumer-reference-evidence.mjs --check --json"
   },
@@ -25,6 +31,7 @@
     "ajv-formats": "3.0.1"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
     "style-dictionary": "5.5.0"
   }
 }

--- a/scripts/agent-native/a2a-projection.mjs
+++ b/scripts/agent-native/a2a-projection.mjs
@@ -1,0 +1,248 @@
+import { cloneAndFreeze, hashCanonical } from "./canonical-json.mjs";
+
+const STATE_MAP = Object.freeze({
+  PENDING: "submitted", CREATED: "submitted", QUEUED: "submitted", SUBMITTED: "submitted",
+  RUNNING: "working", STARTED: "working", IN_PROGRESS: "working", WORKING: "working",
+  COMPLETED: "completed", SUCCEEDED: "completed", SUCCESS: "completed", DONE: "completed",
+  FAILED: "failed", ERROR: "failed", ERRORED: "failed",
+  CANCELED: "canceled", CANCELLED: "canceled", ABORTED: "canceled",
+  REJECTED: "rejected", AUTH_REQUIRED: "auth-required", AUTHENTICATION_REQUIRED: "auth-required",
+});
+
+const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected", "auth-required"]);
+
+export class A2AProjectionError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "A2AProjectionError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+function fail(code, message, path) {
+  throw new A2AProjectionError(code, message, path);
+}
+
+function object(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function pick(value, ...keys) {
+  if (!object(value)) return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key) && value[key] !== undefined) return value[key];
+  return undefined;
+}
+
+function copy(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+function freeze(value) {
+  return cloneAndFreeze(value);
+}
+
+function digest(value) {
+  return hashCanonical(value).slice("sha256:".length);
+}
+
+function idOf(value, ...keys) {
+  const id = pick(value, ...keys, "stableRef", "stable_ref", "id");
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+function domainTaskId(source, task) {
+  const explicit = idOf(source, "domainTaskId", "domain_task_id");
+  const taskRef = idOf(task, "taskId", "task_id", "stableRef", "stable_ref");
+  const generic = !pick(source, "domainTask", "domain_task") ? idOf(source, "taskId", "task_id") : undefined;
+  return explicit
+    ?? taskRef
+    ?? generic
+    ?? `sg:task/a2a-${digest({ task, message: pick(source, "message") }).slice(0, 20)}`;
+}
+
+function domainRunId(source, run, taskId) {
+  const explicit = idOf(source, "domainRunId", "domain_run_id");
+  const runRef = idOf(run, "runId", "run_id", "stableRef", "stable_ref");
+  const generic = !pick(source, "domainRun", "domain_run") ? idOf(source, "runId", "run_id") : undefined;
+  return explicit
+    ?? runRef
+    ?? generic
+    ?? `sg:run/a2a-${digest({ run, taskId }).slice(0, 20)}`;
+}
+
+function protocolIds(source, task, binding, taskId, runId) {
+  const protocolTaskId = pick(source, "protocolTaskId", "protocol_task_id", "a2aTaskId", "a2a_task_id")
+    ?? pick(binding, "protocolTaskId", "protocol_task_id", "a2aTaskId", "a2a_task_id")
+    ?? pick(task, "protocolTaskId", "protocol_task_id", "a2aTaskId", "a2a_task_id")
+    ?? `a2a-task-${digest({ taskId, runId, message: pick(source, "message"), binding }).slice(0, 24)}`;
+  const protocolContextId = pick(source, "protocolContextId", "protocol_context_id", "a2aContextId", "a2a_context_id")
+    ?? pick(binding, "protocolContextId", "protocol_context_id", "a2aContextId", "a2a_context_id")
+    ?? pick(task, "contextId", "context_id")
+    ?? `a2a-context-${digest({ taskId, runId }).slice(0, 24)}`;
+  if (protocolTaskId === taskId || protocolTaskId === runId) fail("protocol_task_id_conflict", "A2A task ID must not equal a domain Task or Run ID", "protocolTaskId");
+  if (protocolContextId === taskId || protocolContextId === runId || protocolContextId === protocolTaskId) fail("protocol_context_id_conflict", "A2A context ID must remain distinct from domain and task IDs", "protocolContextId");
+  return { protocolTaskId: String(protocolTaskId), protocolContextId: String(protocolContextId) };
+}
+
+function makeBinding(source, task, binding, taskId, runId, protocolTaskId, protocolContextId) {
+  const supplied = object(binding) ? copy(binding) : {};
+  const bindingId = pick(supplied, "bindingId", "binding_id", "protocolBindingId", "protocol_binding_id")
+    ?? `sg:binding/a2a-${digest({ taskId, runId, protocolTaskId, protocolContextId }).slice(0, 24)}`;
+  if (typeof bindingId !== "string" || bindingId.length === 0) fail("protocol_binding_required", "ProtocolBinding requires a non-empty binding ID", "protocolBindingId");
+  if (bindingId === taskId || bindingId === runId || bindingId === protocolTaskId || bindingId === protocolContextId) fail("protocol_binding_id_conflict", "ProtocolBinding ID must remain distinct from every correlated ID", "protocolBindingId");
+  return freeze({
+    ...supplied,
+    bindingId,
+    domainRunId: runId,
+    domainTaskId: taskId,
+    protocol: "a2a",
+    protocolBindingId: bindingId,
+    protocolContextId,
+    protocolTaskId,
+    runId,
+    taskId,
+  });
+}
+
+function taskFrom(input) {
+  const source = object(input) ? input : {};
+  const task = object(source.task) ? source.task : source;
+  return object(task.task) && !pick(task, "status", "id", "contextId") ? task.task : task;
+}
+
+function bindingFrom(input, task) {
+  return pick(input, "protocolBinding", "protocol_binding", "binding")
+    ?? pick(task, "protocolBinding", "protocol_binding", "binding")
+    ?? {};
+}
+
+function domainState(input, task) {
+  const source = object(input) ? input : {};
+  const domainTask = pick(source, "domainTask", "domain_task");
+  return pick(domainTask, "state", "status", "taskState", "task_state")
+    ?? pick(task, "domainState", "domain_state")
+    ?? pick(task, "state", "taskState", "task_state")
+    ?? pick(pick(task, "status"), "state", "status")
+    ?? "UNKNOWN";
+}
+
+function taskStatus(task, state) {
+  const status = object(pick(task, "status")) ? copy(task.status) : {};
+  return { ...status, state };
+}
+
+function responseFor(task) {
+  const { protocolBinding: _binding, ...nested } = task;
+  return freeze({ ...task, task: nested });
+}
+
+function projectTask(input, state, mode = "project") {
+  const source = object(input) ? input : {};
+  const task = taskFrom(source);
+  const domainTask = object(pick(source, "domainTask", "domain_task")) ? pick(source, "domainTask", "domain_task") : task;
+  const run = pick(source, "run", "domainRun", "domain_run");
+  const taskId = domainTaskId(source, domainTask);
+  const runId = domainRunId(source, run, taskId);
+  const suppliedBinding = bindingFrom(source, task);
+  const { protocolTaskId, protocolContextId } = protocolIds(source, task, suppliedBinding, taskId, runId);
+  const binding = makeBinding(source, domainTask, suppliedBinding, taskId, runId, protocolTaskId, protocolContextId);
+  const requestedTaskId = pick(source, "taskId", "task_id");
+  const existingProtocolId = pick(task, "id", "protocolTaskId", "protocol_task_id")
+    ?? (object(pick(task, "status")) ? pick(task, "taskId", "task_id") : undefined);
+  const currentProtocolId = mode === "send" ? protocolTaskId : existingProtocolId ?? protocolTaskId;
+  if (requestedTaskId !== undefined && requestedTaskId !== currentProtocolId && requestedTaskId !== protocolTaskId) fail("protocol_task_mismatch", "requested A2A task ID does not match the correlated task", "taskId");
+  const message = pick(source, "message");
+  const history = Array.isArray(pick(task, "history")) ? copy(task.history) : (message ? [copy(message)] : []);
+  const artifacts = Array.isArray(pick(task, "artifacts")) ? copy(task.artifacts) : [];
+  const projected = {
+    artifacts,
+    contextId: protocolContextId,
+    history,
+    id: currentProtocolId,
+    kind: "task",
+    metadata: {
+      ...(object(pick(task, "metadata")) ? copy(task.metadata) : {}),
+      stylegallery: { domainRunId: runId, domainTaskId: taskId, protocolBindingId: binding.protocolBindingId },
+    },
+    protocolBinding: binding,
+    status: taskStatus(task, state),
+  };
+  if (mode === "send") projected.history = message ? [copy(message)] : history;
+  return freeze(projected);
+}
+
+/** Map every domain lifecycle state to an official A2A TaskState value. */
+export function mapTaskState(value) {
+  const raw = typeof value === "string" ? value : pick(value, "state", "status", "taskState", "task_state");
+  const normalized = String(raw ?? "UNKNOWN").trim().toUpperCase().replaceAll("-", "_").replaceAll(" ", "_");
+  return STATE_MAP[normalized] ?? "unknown";
+}
+
+/** Return the deterministic, v1-shaped Agent Card for StyleGallery. */
+export function createAgentCard(input = {}) {
+  const source = object(input) ? input : {};
+  const skills = [
+    ["discover", "Discover StyleGallery capabilities and immutable manifest."],
+    ["resolve", "Resolve a StableRef or VersionID to its immutable object."],
+    ["claims", "Inspect claims, evidence, validation, and governance disposition."],
+    ["context", "Build a bounded retrieval context package with provenance."],
+    ["ops", "List read-only operation specifications and schemas."],
+    ["retrieve", "Retrieve ranked governed knowledge without mutation."],
+  ].map(([id, description]) => ({ description, examples: [], id, inputModes: ["text", "data"], name: id, outputModes: ["text", "data"], tags: ["stylegallery", "knowledge"] }));
+  return freeze({
+    capabilities: { pushNotifications: false, stateTransitionHistory: true, streaming: false },
+    defaultInputModes: ["text", "data"],
+    defaultOutputModes: ["text", "data"],
+    description: typeof source.description === "string" ? source.description : "Evidence-preserving, agent-native StyleGallery knowledge operations.",
+    name: typeof source.name === "string" ? source.name : "StyleGallery Agent",
+    protocolVersion: "1.0",
+    skills,
+    supportsAuthenticatedExtendedCard: false,
+    url: typeof source.url === "string" ? source.url : "https://stylegallery.local/agent",
+    version: typeof source.version === "string" ? source.version : "1.0.0",
+  });
+}
+
+/** Project an A2A SendMessage request into a new submitted protocol task. */
+export function sendMessage(input) {
+  const source = object(input) ? input : fail("send_message_input_required", "sendMessage expects an object");
+  const message = pick(source, "message");
+  if (!object(message)) fail("message_required", "SendMessage requires a message object", "message");
+  const task = projectTask({ ...source, message }, "submitted", "send");
+  return responseFor(task);
+}
+
+/** Project current domain Task/Run state while preserving the A2A task ID. */
+export function getTask(input) {
+  const source = object(input) ? input : fail("get_task_input_required", "getTask expects an object");
+  const task = taskFrom(source);
+  const taskId = pick(source, "taskId", "task_id");
+  if (taskId === undefined && !idOf(task, "id", "taskId", "task_id", "protocolTaskId", "protocol_task_id")) fail("protocol_task_required", "GetTask requires an A2A task ID", "taskId");
+  const state = mapTaskState(domainState(source, task));
+  const projected = projectTask(source, state);
+  return responseFor(projected);
+}
+
+/** Request cancellation; terminal non-canceled states reject invalid transitions. */
+export function cancelTask(input) {
+  const source = object(input) ? input : fail("cancel_task_input_required", "cancelTask expects an object");
+  const task = taskFrom(source);
+  const current = mapTaskState(domainState(source, task));
+  if (TERMINAL_STATES.has(current) && current !== "canceled") fail("cancellation_not_allowed", `cannot cancel a ${current} A2A task`, "task");
+  if (current === "unknown") fail("invalid_task_transition", "cannot cancel an unknown A2A task state", "task");
+  const projected = projectTask(source, "canceled");
+  return responseFor(projected);
+}
+
+export const buildAgentCard = createAgentCard;
+export const projectAgentCard = createAgentCard;
+export const agentCard = createAgentCard;
+export const projectSendMessage = sendMessage;
+export const handleSendMessage = sendMessage;
+export const projectGetTask = getTask;
+export const handleGetTask = getTask;
+export const projectCancelTask = cancelTask;
+export const handleCancelTask = cancelTask;
+export const projectTaskState = mapTaskState;
+export const toA2ATaskState = mapTaskState;

--- a/scripts/agent-native/agui-projection.mjs
+++ b/scripts/agent-native/agui-projection.mjs
@@ -1,0 +1,178 @@
+import { canonicalize, cloneAndFreeze, hashCanonical } from "./canonical-json.mjs";
+
+const TERMINAL = new Set(["RUN_FINISHED", "RUN_ERROR"]);
+const EVENT_TYPES = new Set([
+  "RUN_STARTED", "RUN_FINISHED", "RUN_ERROR",
+  "TEXT_MESSAGE_START", "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_END",
+  "TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_ARGUMENTS", "TOOL_CALL_END",
+  "STATE_SNAPSHOT", "STATE_DELTA",
+]);
+
+export class AgUiProjectionError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "AgUiProjectionError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+function pick(value, ...keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key) && value[key] !== undefined) return value[key];
+  return undefined;
+}
+
+function text(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function domainId(value, ...keys) {
+  return text(pick(value, ...keys, "stable_ref", "stableRef", "id"), "unknown");
+}
+
+function bindingIds(binding, task, run) {
+  const bindingId = text(pick(binding, "binding_id", "bindingId", "protocol_binding_id", "protocolBindingId"), "sg:binding/agui");
+  const taskId = domainId(task, "task_id", "taskId");
+  const runId = domainId(run, "run_id", "runId");
+  const taskProtocolId = text(
+    pick(binding, "agui_task_id", "aguiTaskId", "protocol_task_id", "protocolTaskId", "protocolTask"),
+    `agui-task-${hashCanonical({ bindingId, taskId }).slice(7, 23)}`,
+  );
+  const runProtocolId = text(
+    pick(binding, "agui_run_id", "aguiRunId", "protocol_run_id", "protocolRunId", "protocolRun"),
+    `agui-run-${hashCanonical({ bindingId, runId }).slice(7, 23)}`,
+  );
+  const threadId = text(pick(binding, "thread_id", "threadId", "agui_thread_id", "aguiThreadId"), taskProtocolId);
+  return { bindingId, domainTaskId: taskId, domainRunId: runId, taskProtocolId, runProtocolId, threadId };
+}
+
+function eventType(event) {
+  return String(pick(event, "type", "eventType", "event_type", "name") ?? "")
+    .trim().toUpperCase().replaceAll("-", "_");
+}
+
+function asEvents(input) {
+  if (Array.isArray(input)) return input;
+  return pick(input, "events", "items") ?? null;
+}
+
+function failure(code, message, path) {
+  return path ? { code, message, path } : { code, message };
+}
+
+/** Validate an AG-UI event sequence before it crosses the protocol boundary. */
+export function validateAgUiTransitions(input) {
+  const events = asEvents(input);
+  const failures = [];
+  if (!Array.isArray(events)) return { ok: false, valid: false, failures: [failure("agui_events_required", "events must be an array", "events")] };
+  if (events.length === 0) failures.push(failure("agui_events_empty", "AG-UI event sequence cannot be empty", "events"));
+  let started = false;
+  let ended = false;
+  let openTextId = null;
+  let openToolId = null;
+  let runId = null;
+  let terminalCount = 0;
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    const type = eventType(event);
+    const path = `/events/${index}`;
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      failures.push(failure("agui_event_invalid", "event must be an object", path));
+      continue;
+    }
+    if (!EVENT_TYPES.has(type)) failures.push(failure("agui_event_type_invalid", `unsupported AG-UI event type ${type || "<empty>"}`, `${path}/type`));
+    const eventRunId = pick(event, "runId", "run_id");
+    if (eventRunId !== undefined && runId !== null && eventRunId !== runId) failures.push(failure("agui_run_id_mismatch", "all events must use one protocol run ID", `${path}/runId`));
+    if (eventRunId !== undefined) runId = eventRunId;
+    if (ended) failures.push(failure("agui_event_after_terminal", "no event may follow a terminal event", path));
+    if (type === "RUN_STARTED") {
+      if (started) failures.push(failure("agui_run_started_duplicate", "RUN_STARTED may occur only once", path));
+      if (index !== 0) failures.push(failure("agui_run_started_not_first", "RUN_STARTED must be the first event", path));
+      started = true;
+      continue;
+    }
+    if (!started) failures.push(failure("agui_run_not_started", "event cannot precede RUN_STARTED", path));
+    if (TERMINAL.has(type)) {
+      terminalCount += 1;
+      ended = true;
+      if (openTextId !== null) failures.push(failure("agui_text_message_open", "terminal event closed an open text message", path));
+      if (openToolId !== null) failures.push(failure("agui_tool_call_open", "terminal event closed an open tool call", path));
+      continue;
+    }
+    if (type === "TEXT_MESSAGE_START") {
+      const current = pick(event, "messageId", "message_id");
+      if (typeof current !== "string" || current.length === 0) failures.push(failure("agui_message_id_required", "TEXT_MESSAGE_START requires messageId", `${path}/messageId`));
+      if (openTextId !== null) failures.push(failure("agui_text_message_nested", "text messages cannot be nested", path));
+      openTextId = current ?? null;
+    } else if (type === "TEXT_MESSAGE_CONTENT") {
+      const current = pick(event, "messageId", "message_id");
+      if (openTextId === null || current !== openTextId) failures.push(failure("agui_text_message_not_open", "TEXT_MESSAGE_CONTENT must target an open message", path));
+    } else if (type === "TEXT_MESSAGE_END") {
+      const current = pick(event, "messageId", "message_id");
+      if (openTextId === null || current !== openTextId) failures.push(failure("agui_text_message_not_open", "TEXT_MESSAGE_END must target an open message", path));
+      openTextId = null;
+    } else if (type === "TOOL_CALL_START") {
+      const current = pick(event, "toolCallId", "tool_call_id");
+      if (typeof current !== "string" || current.length === 0) failures.push(failure("agui_tool_call_id_required", "TOOL_CALL_START requires toolCallId", `${path}/toolCallId`));
+      if (openToolId !== null) failures.push(failure("agui_tool_call_nested", "tool calls cannot be nested", path));
+      openToolId = current ?? null;
+    } else if (type === "TOOL_CALL_ARGS" || type === "TOOL_CALL_ARGUMENTS") {
+      const current = pick(event, "toolCallId", "tool_call_id");
+      if (openToolId === null || current !== openToolId) failures.push(failure("agui_tool_call_not_open", "TOOL_CALL_ARGS must target an open tool call", path));
+    } else if (type === "TOOL_CALL_END") {
+      const current = pick(event, "toolCallId", "tool_call_id");
+      if (openToolId === null || current !== openToolId) failures.push(failure("agui_tool_call_not_open", "TOOL_CALL_END must target an open tool call", path));
+      openToolId = null;
+    }
+  }
+  if (!started) failures.push(failure("agui_run_started_required", "sequence must contain RUN_STARTED", "events"));
+  if (terminalCount !== 1) failures.push(failure("agui_terminal_count_invalid", "sequence must contain exactly one terminal event", "events"));
+  if (terminalCount === 1 && !TERMINAL.has(eventType(events.at(-1)))) failures.push(failure("agui_terminal_not_last", "terminal event must be last", `/events/${events.length - 1}`));
+  if (openTextId !== null) failures.push(failure("agui_text_message_unclosed", "text message did not receive TEXT_MESSAGE_END", "events"));
+  if (openToolId !== null) failures.push(failure("agui_tool_call_unclosed", "tool call did not receive TOOL_CALL_END", "events"));
+  return { ok: failures.length === 0, valid: failures.length === 0, failures };
+}
+
+function protocolEvent(type, ids, fields = {}) {
+  return { type, runId: ids.runProtocolId, ...fields };
+}
+
+/** Project a domain Task/Run outcome to one deterministic AG-UI 0.0.57 stream. */
+export function projectAgUiEvents(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new AgUiProjectionError("agui_input_invalid", "projectAgUiEvents expects an object");
+  const ids = bindingIds(pick(input, "protocolBinding", "protocol_binding") ?? {}, input.task ?? {}, input.run ?? {});
+  const textValue = String(pick(input, "text", "message") ?? "");
+  const messageValue = pick(input, "messageId", "message_id") ?? `${ids.runProtocolId}:message`;
+  const tool = pick(input, "toolCall", "tool_call") ?? {};
+  const toolId = text(pick(tool, "id", "toolCallId", "tool_call_id"), `${ids.runProtocolId}:tool`);
+  const toolName = text(pick(tool, "name", "toolName", "tool_name"), "operation");
+  const toolArgs = pick(tool, "args", "arguments") ?? {};
+  const state = pick(input, "state", "snapshot") ?? {};
+  const outcome = String(pick(input, "outcome", "status") ?? pick(input.run, "state", "status") ?? pick(input.task, "state", "status") ?? "COMPLETED").toUpperCase();
+  const success = new Set(["COMPLETED", "SUCCEEDED", "SUCCESS", "OK", "PASS", "PASSED"]).has(outcome);
+  const correlation = { protocolBindingId: ids.bindingId, domainTaskId: ids.domainTaskId, domainRunId: ids.domainRunId };
+  const events = [
+    protocolEvent("RUN_STARTED", ids, { threadId: ids.threadId, input: pick(input.task, "intent", "request") ?? {}, metadata: correlation }),
+    protocolEvent("TEXT_MESSAGE_START", ids, { messageId: messageValue, role: "assistant" }),
+    protocolEvent("TEXT_MESSAGE_CONTENT", ids, { messageId: messageValue, delta: textValue }),
+    protocolEvent("TEXT_MESSAGE_END", ids, { messageId: messageValue }),
+    protocolEvent("TOOL_CALL_START", ids, { toolCallId: toolId, toolCallName: toolName }),
+    protocolEvent("TOOL_CALL_ARGS", ids, { toolCallId: toolId, delta: typeof toolArgs === "string" ? toolArgs : canonicalize(toolArgs) }),
+    protocolEvent("TOOL_CALL_END", ids, { toolCallId: toolId }),
+    protocolEvent("STATE_SNAPSHOT", ids, { snapshot: state }),
+    success
+      ? protocolEvent("RUN_FINISHED", ids, { threadId: ids.threadId, result: pick(input, "result", "output") ?? { status: outcome } })
+      : protocolEvent("RUN_ERROR", ids, { threadId: ids.threadId, message: text(pick(input, "error", "errorMessage"), outcome) }),
+  ];
+  const validation = validateAgUiTransitions(events);
+  if (!validation.ok) throw new AgUiProjectionError("agui_projection_invalid", "generated event sequence failed transition validation");
+  return cloneAndFreeze({ ok: true, events, protocolBinding: { ...correlation, protocol: "ag-ui" }, protocolIds: { threadId: ids.threadId, taskId: ids.taskProtocolId, runId: ids.runProtocolId } });
+}
+
+export const projectAGUIEvents = projectAgUiEvents;
+export const projectAguiEvents = projectAgUiEvents;
+export const createAgUiEvents = projectAgUiEvents;
+export const validateAGUITransitions = validateAgUiTransitions;
+export const assertAgUiTransitions = validateAgUiTransitions;
+export const validateEventSequence = validateAgUiTransitions;

--- a/scripts/agent-native/canonical-json.mjs
+++ b/scripts/agent-native/canonical-json.mjs
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Errors from the identity kernel carry a stable machine-readable code.  The
+ * callers use these errors at protocol boundaries, so do not rely on the
+ * wording of `message` for branching.
+ */
+export class CanonicalJsonError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "CanonicalJsonError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+function fail(code, message, path) {
+  throw new CanonicalJsonError(code, message, path);
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object") return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function encode(value, path, stack) {
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "string": return JSON.stringify(value);
+    case "boolean": return value ? "true" : "false";
+    case "number":
+      if (!Number.isFinite(value)) fail("canonical_number_invalid", "numbers must be finite", path);
+      return Object.is(value, -0) ? "0" : JSON.stringify(value);
+    case "bigint": fail("canonical_type_unsupported", "bigint is not JSON data", path);
+    case "undefined": fail("canonical_value_undefined", "undefined is not JSON data", path);
+    case "function": fail("canonical_type_unsupported", "functions are not JSON data", path);
+    case "symbol": fail("canonical_type_unsupported", "symbols are not JSON data", path);
+    default: break;
+  }
+
+  if (stack.has(value)) fail("canonical_cycle", "cyclic values cannot be canonicalized", path);
+  stack.add(value);
+  let result;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      if (!Object.hasOwn(value, index)) fail("canonical_array_hole", "sparse arrays are not canonical JSON", `${path}/${index}`);
+    }
+    for (const key of Object.keys(value)) {
+      if (!/^(0|[1-9][0-9]*)$/.test(key) || Number(key) >= value.length) fail("canonical_array_property", "arrays may contain only indexed JSON values", `${path}/${key}`);
+    }
+    result = `[${value.map((item, index) => encode(item, `${path}/${index}`, stack)).join(",")}]`;
+  } else if (isPlainObject(value)) {
+    const keys = Reflect.ownKeys(value);
+    if (keys.some((key) => typeof key !== "string")) fail("canonical_symbol_key", "object keys must be strings", path);
+    const properties = Object.getOwnPropertyDescriptors(value);
+    const parts = keys.sort().map((key) => {
+      const descriptor = properties[key];
+      if (!descriptor || !Object.hasOwn(descriptor, "value")) fail("canonical_accessor", `accessor property ${key} is not canonical data`, `${path}/${key}`);
+      return `${JSON.stringify(key)}:${encode(descriptor.value, `${path}/${key}`, stack)}`;
+    });
+    result = `{${parts.join(",")}}`;
+  } else {
+    fail("canonical_type_unsupported", `unsupported value type ${Object.prototype.toString.call(value)}`, path);
+  }
+  stack.delete(value);
+  return result;
+}
+
+/** Return recursively key-sorted, whitespace-free UTF-8 JSON text. */
+export function canonicalize(value) {
+  return encode(value, "", new WeakSet());
+}
+
+export const canonicalJson = canonicalize;
+export const stringifyCanonical = canonicalize;
+
+/** Return the SHA-256 digest of canonical JSON bytes, with an explicit suite. */
+export function hashCanonical(value) {
+  const bytes = canonicalize(value);
+  return `sha256:${createHash("sha256").update(Buffer.from(bytes, "utf8")).digest("hex")}`;
+}
+
+/** Hash already-canonical UTF-8 JSON bytes when a caller has the bytes. */
+export function hashCanonicalBytes(bytes) {
+  if (typeof bytes !== "string" && !(bytes instanceof Uint8Array)) throw new CanonicalJsonError("canonical_bytes_required", "canonical bytes must be text or Uint8Array");
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export const sha256Canonical = hashCanonical;
+export const digestCanonical = hashCanonical;
+
+/** Deep-freeze canonical records before they cross an append-only boundary. */
+export function deepFreeze(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object" || seen.has(value)) return value;
+  seen.add(value);
+  for (const key of Reflect.ownKeys(value)) deepFreeze(value[key], seen);
+  return Object.freeze(value);
+}
+
+export function cloneAndFreeze(value) {
+  let clone;
+  try {
+    clone = structuredClone(value);
+  } catch (error) {
+    throw new CanonicalJsonError("canonical_clone_failed", error instanceof Error ? error.message : String(error));
+  }
+  return deepFreeze(clone);
+}

--- a/scripts/agent-native/cli-adapter.mjs
+++ b/scripts/agent-native/cli-adapter.mjs
@@ -1,0 +1,68 @@
+import { deepFreeze } from "./canonical-json.mjs";
+import { agentNativeRegistry } from "./registry.mjs";
+
+const COMMANDS = new Set(["claims", "context", "discover", "ops", "resolve"]);
+const TARGET_COMMANDS = new Set(["claims", "context", "resolve"]);
+
+function issue(code, message, recordPath = "") {
+  return recordPath ? { code, message, path: recordPath } : { code, message };
+}
+
+function failed(operation, failure) {
+  return deepFreeze({ failures: [failure], ok: false, operation });
+}
+
+export function parseCliArguments(args) {
+  if (!Array.isArray(args)) return failed(null, issue("argument_list_invalid", "CLI arguments must be an array"));
+  let command;
+  let format = "json";
+  const operands = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--format") {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("--")) {
+        return failed(command ?? null, issue("argument_value_required", "--format requires a value", "--format"));
+      }
+      if (value !== "json") return failed(command ?? null, issue("format_unsupported", `unsupported format ${value}`, "--format"));
+      format = value;
+      index += 1;
+      continue;
+    }
+    if (typeof argument !== "string" || argument.startsWith("--")) {
+      return failed(command ?? null, issue("argument_unknown", `unknown argument ${String(argument)}`, String(argument)));
+    }
+    if (command === undefined) command = argument;
+    else operands.push(argument);
+  }
+  if (command === undefined) return failed(null, issue("argument_value_required", "a command is required", "command"));
+  if (!COMMANDS.has(command)) return failed(command, issue("command_unknown", `unknown command ${command}`, "command"));
+  const required = TARGET_COMMANDS.has(command);
+  if (required && operands.length === 0) {
+    return failed(command, issue("argument_value_required", `${command} requires a StableRef or VersionID`, "reference"));
+  }
+  if ((!required && operands.length > 0) || operands.length > 1) {
+    return failed(command, issue("argument_unknown", `unexpected positional argument ${operands[required ? 1 : 0]}`, "argument"));
+  }
+  return deepFreeze({ command, format, input: required ? { reference: operands[0] } : {}, ok: true });
+}
+
+export function executeCli(args, registry = agentNativeRegistry) {
+  const parsed = parseCliArguments(args);
+  if (!parsed.ok) return parsed;
+  if (!registry || typeof registry.invoke !== "function") {
+    return failed(parsed.command, issue("registry_invalid", "CLI registry must expose invoke"));
+  }
+  return registry.invoke(parsed.command, parsed.input);
+}
+
+export function serializeCliReport(report) {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function runCli(args, registry = agentNativeRegistry) {
+  const report = executeCli(args, registry);
+  return deepFreeze({ exitCode: report.ok ? 0 : 1, output: serializeCliReport(report), report });
+}
+
+export const invokeCli = executeCli;

--- a/scripts/agent-native/events.mjs
+++ b/scripts/agent-native/events.mjs
@@ -1,0 +1,113 @@
+import { cloneAndFreeze, canonicalize, hashCanonical } from "./canonical-json.mjs";
+
+function sourceObject(value, name) {
+  if (Array.isArray(value)) return { events: value };
+  if (!value || typeof value !== "object") throw new TypeError(`${name} expects an object`);
+  return value;
+}
+
+function pick(value, ...keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key)) return value[key];
+  return undefined;
+}
+
+function eventId(event) {
+  return pick(event, "event_id", "eventId", "id", "stable_ref", "stableRef");
+}
+
+function parentIds(event) {
+  const parents = pick(event, "parents", "parent_ids", "parentIds");
+  if (parents === undefined || parents === null) return [];
+  if (!Array.isArray(parents)) throw new TypeError("event parents must be an array");
+  return [...new Set(parents.map((parent) => {
+    if (typeof parent !== "string" || parent.length === 0) throw new TypeError("event parent IDs must be non-empty strings");
+    return parent;
+  }))].sort();
+}
+
+function canonicalFreeze(value) {
+  return cloneAndFreeze(JSON.parse(canonicalize(value)));
+}
+
+function normalizeEvent(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("event must be an object");
+  const copy = structuredClone(input);
+  const id = eventId(copy);
+  if (id !== undefined && (typeof id !== "string" || id.length === 0)) throw new TypeError("event ID must be a non-empty string");
+  const stableRef = pick(copy, "stable_ref", "stableRef");
+  const parents = parentIds(copy);
+  delete copy.eventId;
+  delete copy.event_id;
+  delete copy.parentIds;
+  delete copy.parent_ids;
+  delete copy.parents;
+  delete copy.id;
+  delete copy.stableRef;
+  delete copy.stable_ref;
+  const body = { ...copy, parents };
+  if (stableRef !== undefined) body.stable_ref = stableRef;
+  const stableId = typeof id === "string" && id.length > 0 ? id : `sg:event/${hashCanonical(body).slice("sha256:".length)}`;
+  return { event_id: stableId, parents, ...body };
+}
+
+function normalizedEvents(value) {
+  const source = sourceObject(value, "event collection");
+  const events = pick(source, "events", "items", "entries");
+  if (!Array.isArray(events)) throw new TypeError("events must be an array");
+  const result = [];
+  const byId = new Map();
+  for (const item of events) {
+    const normalized = normalizeEvent(item);
+    const id = normalized.event_id;
+    const previous = byId.get(id);
+    if (previous) {
+      if (canonicalize(previous) !== canonicalize(normalized)) throw new TypeError(`event ${id} is immutable`);
+      continue;
+    }
+    byId.set(id, normalized);
+    result.push(normalized);
+  }
+  const ids = new Set(result.map((item) => item.event_id));
+  const visiting = new Set();
+  const visited = new Set();
+  const eventById = new Map(result.map((item) => [item.event_id, item]));
+  const visit = (id) => {
+    if (visiting.has(id)) throw new TypeError(`event cycle includes ${id}`);
+    if (visited.has(id)) return;
+    visiting.add(id);
+    for (const parent of eventById.get(id).parents) if (eventById.has(parent)) visit(parent);
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const id of ids) visit(id);
+  return result;
+}
+
+/**
+ * Append one event to an immutable causal event collection. Existing IDs are
+ * idempotent only when their canonical bytes are identical; a changed payload
+ * is rejected rather than silently rewriting history.
+ */
+export function appendEvent(input) {
+  const source = sourceObject(input, "appendEvent");
+  const existing = normalizedEvents(source);
+  const appended = normalizeEvent(pick(source, "event") ?? source);
+  const existingById = new Map(existing.map((item) => [item.event_id, item]));
+  const previous = existingById.get(appended.event_id);
+  if (previous && canonicalize(previous) !== canonicalize(appended)) throw new TypeError(`event ${appended.event_id} is immutable`);
+  if (previous) return canonicalFreeze(existing);
+  return canonicalFreeze(normalizedEvents({ events: [...existing, appended] }));
+}
+
+export const appendCausalEvent = appendEvent;
+
+/** Return the deterministic leaf IDs of an append-only causal DAG. */
+export function eventHeads(input) {
+  const events = normalizedEvents(input);
+  const ids = new Set(events.map((item) => item.event_id));
+  const referenced = new Set(events.flatMap((item) => item.parents.filter((parent) => ids.has(parent))));
+  return canonicalFreeze([...ids].filter((id) => !referenced.has(id)).sort());
+}
+
+export const getEventHeads = eventHeads;

--- a/scripts/agent-native/execution.mjs
+++ b/scripts/agent-native/execution.mjs
@@ -1,0 +1,227 @@
+import { deepFreeze, hashCanonical } from "./canonical-json.mjs";
+import { createVersionId } from "./identity.mjs";
+
+const CONTROL = new Set(["schema_version", "record_kind", "version_id", "versionId"]);
+const EFFECTS = new Set(["NONE", "LOCAL", "EXTERNAL"]);
+
+function sourceObject(input, name) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError(`${name} expects an object parameter`);
+  return input;
+}
+
+function value(input, ...keys) {
+  if (input === null || input === undefined) return undefined;
+  for (const key of keys) if (Object.hasOwn(input, key) && input[key] !== undefined) return input[key];
+  return undefined;
+}
+
+function copy(input) {
+  return input === undefined ? undefined : structuredClone(input);
+}
+
+function refOf(input, prefixes, name) {
+  const ref = value(input, "stable_ref", "stableRef", "id", ...prefixes);
+  if (typeof ref !== "string" || ref.length === 0) throw new TypeError(`${name} stable reference is required`);
+  return ref.includes("@sha256:") ? ref.slice(0, ref.indexOf("@sha256:")) : ref;
+}
+
+function versionId(stableRef, payload) {
+  return createVersionId({ stableRef, payload });
+}
+
+function record(stableRef, recordKind, payload) {
+  const body = { schema_version: "1.0", record_kind: recordKind, stable_ref: stableRef, ...payload };
+  return deepFreeze({ ...body, version_id: versionId(stableRef, body) });
+}
+
+function normalizedFields(input, omit = []) {
+  const ignored = new Set([...CONTROL, "stable_ref", "stableRef", "id", ...omit]);
+  return Object.fromEntries(Object.entries(input).filter(([key, item]) => !ignored.has(key) && item !== undefined).map(([key, item]) => [key, copy(item)]));
+}
+
+function upper(input, fallback) {
+  return typeof input === "string" ? input.toUpperCase() : fallback;
+}
+
+function operationNames(operation) {
+  if (!operation || typeof operation !== "object") return [];
+  return [value(operation, "operation", "name"), value(operation, "stable_ref", "stableRef")].filter((item) => typeof item === "string");
+}
+
+function wildcardMatch(pattern, candidate) {
+  if (typeof pattern !== "string" || typeof candidate !== "string") return false;
+  if (pattern === "*") return true;
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
+  return new RegExp(`^${escaped}$`).test(candidate);
+}
+
+/** Define a deterministic, immutable operation specification. */
+export function defineOperation(input) {
+  const source = sourceObject(input, "defineOperation");
+  const stableRef = refOf(source, ["operation"], "defineOperation");
+  const effectClass = upper(value(source, "effect_class", "effectClass", "effect"), "NONE");
+  if (!EFFECTS.has(effectClass)) throw new TypeError("defineOperation.effect_class must be NONE, LOCAL, or EXTERNAL");
+  const operationName = value(source, "operation", "name") ?? stableRef.slice(stableRef.lastIndexOf("/") + 1);
+  const payload = {
+    ...normalizedFields(source, ["operation", "name", "effect", "effectClass", "effect_class", "idempotent", "isIdempotent", "requiredCapability", "capability", "inputSchema", "outputSchema"]),
+    adapters: [...new Set((value(source, "adapters", "adapter_exposure", "adapterExposure") ?? []).filter((item) => typeof item === "string"))].sort(),
+    effect_class: effectClass,
+    idempotent: value(source, "idempotent", "isIdempotent") !== false,
+    input_schema: copy(value(source, "input_schema", "inputSchema") ?? { type: "object" }),
+    name: operationName,
+    operation: operationName,
+    output_schema: copy(value(source, "output_schema", "outputSchema") ?? { type: "object" }),
+    required_capability: value(source, "required_capability", "requiredCapability", "capability") ?? null,
+  };
+  return record(stableRef, "operation", payload);
+}
+
+function grantFor(input) {
+  return value(input, "grant", "capability");
+}
+
+function connectorReceiptId(input) {
+  const receipt = value(input, "connector_receipt", "connectorReceipt", "receiptId", "receipt_id");
+  return typeof receipt === "string" && receipt.trim().length > 0 ? receipt : null;
+}
+
+/** Evaluate capability, subject, resource, expiry, and call-limit policy. */
+export function authorizeOperation(input) {
+  const source = sourceObject(input, "authorizeOperation");
+  const operation = value(source, "operation", "operationSpec");
+  const grant = grantFor(source);
+  const subject = value(source, "subject", "principal");
+  const resource = value(source, "resource", "resourceRef", "stable_ref", "stableRef");
+  const now = value(source, "now", "evaluated_at", "evaluatedAt") ?? "1970-01-01T00:00:00.000Z";
+  const names = operationNames(operation);
+  const required = value(operation ?? {}, "required_capability", "requiredCapability", "capability");
+  const grantedCapability = value(grant ?? {}, "capability", "name");
+  const operationGrant = value(grant ?? {}, "operations", "operation");
+  const operations = Array.isArray(operationGrant) ? operationGrant : operationGrant ? [operationGrant] : [];
+  const scopeGrant = value(grant ?? {}, "resource_scope", "resourceScope", "resources");
+  const scopes = Array.isArray(scopeGrant) ? scopeGrant : scopeGrant ? [scopeGrant] : [];
+  const expiresAt = value(grant ?? {}, "expires_at", "expiresAt", "expiry");
+  const used = Number(value(grant ?? {}, "used", "used_calls", "usedCalls", "calls_used", "callsUsed") ?? 0);
+  const limits = value(grant ?? {}, "limits") ?? {};
+  const maxCalls = Number(value(grant ?? {}, "max_calls", "maxCalls") ?? value(limits, "maxCalls", "calls") ?? Number.POSITIVE_INFINITY);
+  const failures = [];
+  if (!grant || typeof grant !== "object") failures.push("capability_missing");
+  if (typeof subject !== "string" || subject !== value(grant ?? {}, "subject", "principal")) failures.push("subject_denied");
+  if (required && grantedCapability !== required) failures.push("capability_denied");
+  if (operations.length === 0 || !names.some((name) => operations.includes(name))) failures.push("operation_denied");
+  if (scopes.length > 0 && !scopes.some((scope) => wildcardMatch(scope, resource))) failures.push("resource_denied");
+  if (expiresAt && String(now) >= String(expiresAt)) failures.push("grant_expired");
+  if (Number.isFinite(maxCalls) && used >= maxCalls) failures.push("grant_limit_exceeded");
+  const allowed = failures.length === 0;
+  const decision = {
+    allowed,
+    capability: grantedCapability ?? null,
+    evaluated_at: String(now),
+    operation: names[0] ?? null,
+    reason: allowed ? "allowed" : failures[0],
+    resource: resource ?? null,
+    subject: subject ?? null,
+  };
+  return deepFreeze({ allowed, decision, policy_decision: decision, failures });
+}
+
+/** Re-check policy immediately before a potentially effectful attempt. */
+export function authorizeEffect(input) {
+  const source = sourceObject(input, "authorizeEffect");
+  return authorizeOperation({ ...source, operation: value(source, "operation", "operationSpec") });
+}
+
+export function createTask(input) {
+  const source = sourceObject(input, "createTask");
+  const stableRef = refOf(source, ["taskId", "task_id"], "createTask");
+  return record(stableRef, "task", {
+    ...normalizedFields(source, ["taskId", "task_id", "intent", "request", "requiredResult", "required_result", "result", "state", "status"]),
+    intent: copy(value(source, "intent", "request") ?? {}),
+    required_result: copy(value(source, "required_result", "requiredResult", "result") ?? {}),
+    state: upper(value(source, "state", "status"), "SUBMITTED"),
+    task_id: stableRef,
+  });
+}
+
+export function startRun(input) {
+  const source = sourceObject(input, "startRun");
+  const task = value(source, "task");
+  const taskId = value(task ?? {}, "task_id", "taskId", "stable_ref", "stableRef") ?? value(source, "task_id", "taskId");
+  if (typeof taskId !== "string" || taskId.length === 0) throw new TypeError("startRun.task_id is required");
+  const stableRef = refOf(source, ["runId", "run_id"], "startRun");
+  return record(stableRef, "run", {
+    ...normalizedFields(source, ["runId", "run_id", "task", "taskId", "task_id", "state", "status"]),
+    input: copy(value(source, "input", "arguments") ?? {}),
+    run_id: stableRef,
+    state: upper(value(source, "state", "status"), "RUNNING"),
+    task_id: taskId,
+  });
+}
+
+export function recordEffectAttempt(input) {
+  const source = sourceObject(input, "recordEffectAttempt");
+  const stableRef = refOf(source, ["effectId", "effect_id", "effect"], "recordEffectAttempt");
+  const effectClass = upper(value(source, "effect_class", "effectClass", "class"), "EXTERNAL");
+  const connectorReceipt = connectorReceiptId(source);
+  const suppliedState = upper(value(source, "state", "status", "effect_state", "effectState"), undefined);
+  const state = effectClass === "EXTERNAL"
+    ? (connectorReceipt ? "COMMITTED" : "UNCERTAIN")
+    : (suppliedState ?? "PLANNED");
+  return record(stableRef, "effect", {
+    ...normalizedFields(source, ["effectId", "effect_id", "effect", "effect_class", "effectClass", "class", "connector_receipt", "connectorReceipt", "receiptId", "receipt_id", "state", "status", "effect_state", "effectState"]),
+    attempt: value(source, "attempt") ?? null,
+    connector_receipt: connectorReceipt,
+    effect_class: effectClass,
+    effect_id: stableRef,
+    idempotency_key: value(source, "idempotency_key", "idempotencyKey") ?? null,
+    run_id: value(source, "run_id", "runId") ?? value(value(source, "run"), "run_id", "runId") ?? null,
+    state,
+    task_id: value(source, "task_id", "taskId") ?? value(value(source, "task"), "task_id", "taskId") ?? null,
+  });
+}
+
+export function reconcileEffect(input) {
+  const source = sourceObject(input, "reconcileEffect");
+  const effect = source.effect && typeof source.effect === "object" ? source.effect : source;
+  const observations = [...(Array.isArray(value(source, "observations")) ? value(source, "observations") : []), ...(value(source, "observation") ? [value(source, "observation")] : [])];
+  const statuses = observations.map((item) => upper(value(item ?? {}, "status", "state", "effect_state", "effectState"), "UNKNOWN"));
+  const positiveStatuses = new Set(["COMMITTED", "SUCCEEDED", "SUCCESS"]);
+  const positive = statuses.some((status) => positiveStatuses.has(status));
+  const negative = statuses.includes("ABSENT") || statuses.includes("FAILED") || statuses.includes("NOT_FOUND");
+  const strategy = upper(value(source, "strategy"), "RECONCILE");
+  let state = upper(value(effect, "state", "status", "effect_state", "effectState"), "UNCERTAIN");
+  const receiptObservation = observations.find((item) => positiveStatuses.has(upper(value(item ?? {}, "status", "state", "effect_state", "effectState"), "UNKNOWN")) && connectorReceiptId(item));
+  const connectorReceipt = connectorReceiptId(receiptObservation) ?? connectorReceiptId(effect);
+  if (positive && negative) state = "UNCERTAIN";
+  else if (positive) state = connectorReceipt ? "COMMITTED" : "UNCERTAIN";
+  else if (negative && strategy === "COMPENSATE") state = "COMPENSATED";
+  else if (negative) state = "FAILED";
+  else if (state === "COMMITTED" && !connectorReceipt) state = "UNCERTAIN";
+  const stableRef = refOf(effect, ["effect_id", "effectId", "effect"], "reconcileEffect");
+  return record(stableRef, "effect", { ...normalizedFields(effect, ["version_id", "versionId", "state", "status", "effect_state", "effectState", "connector_receipt", "connectorReceipt"]), connector_receipt: connectorReceipt, state });
+}
+
+export function createReceipt(input) {
+  const source = sourceObject(input, "createReceipt");
+  const operation = value(source, "operation", "operationSpec");
+  const task = value(source, "task");
+  const run = value(source, "run");
+  const effects = value(source, "effects") ?? (value(source, "effect") ? [value(source, "effect")] : []);
+  const inputValue = value(source, "input", "normalized_input", "normalizedInput") ?? null;
+  const outputValue = value(source, "output", "normalized_output", "normalizedOutput") ?? null;
+  const taskId = value(source, "task_id", "taskId") ?? value(task ?? {}, "task_id", "taskId", "stable_ref", "stableRef") ?? null;
+  const runId = value(source, "run_id", "runId") ?? value(run ?? {}, "run_id", "runId", "stable_ref", "stableRef") ?? null;
+  const effectIds = effects.map((effect) => value(effect ?? {}, "effect_id", "effectId", "stable_ref", "stableRef", "id")).filter((id) => typeof id === "string");
+  const base = { input_digest: hashCanonical(inputValue), operation: value(operation ?? {}, "operation", "name", "stable_ref", "stableRef") ?? null, output_digest: hashCanonical(outputValue), run_id: runId, task_id: taskId, effect_ids: [...new Set(effectIds)].sort() };
+  const stableRef = value(source, "receipt_id", "receiptId", "stable_ref", "stableRef") ?? `sg:receipt/${hashCanonical(base).slice(7, 23)}`;
+  return record(stableRef, "invocation_receipt", {
+    ...base,
+    causal_parents: [...new Set((value(source, "causal_parents", "causalParents", "parents") ?? []).filter((item) => typeof item === "string"))].sort(),
+    effects: copy(effects),
+    policy_decision: copy(value(source, "policy_decision", "policyDecision") ?? null),
+  });
+}
+
+export const defineOperationSpec = defineOperation;
+export const authorizeCapability = authorizeOperation;
+export const createInvocationReceipt = createReceipt;

--- a/scripts/agent-native/fixture.mjs
+++ b/scripts/agent-native/fixture.mjs
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseStrictJson } from "../strict-json.mjs";
+import { deepFreeze, hashCanonical } from "./canonical-json.mjs";
+import { defineOperation } from "./execution.mjs";
+import { createManifest, createStableRef, createVersionId } from "./identity.mjs";
+import {
+  createClaim,
+  createEvidenceLink,
+  createGovernanceDecision,
+  createPolicyDisposition,
+  createValidationReport,
+} from "./knowledge.mjs";
+
+export const EDITORIAL_PROFILE_REF = "sg:profile/editorial-reference-profile";
+export const FIXTURE_MANIFEST_REF = "sg:manifest/agent-native-fixture";
+export const REGISTRY_SOURCE_URL = new URL("../../consumer-reference/agent-native/registry.json", import.meta.url);
+
+export class FixtureError extends TypeError {
+  constructor(code, message, recordPath = "") {
+    super(message);
+    this.name = "FixtureError";
+    this.code = code;
+    if (recordPath) this.path = recordPath;
+  }
+}
+
+function fail(code, message, recordPath = "") {
+  throw new FixtureError(code, message, recordPath);
+}
+
+function plainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function repositoryRoot() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+}
+
+function safeRepositoryFile(relative) {
+  if (typeof relative !== "string" || relative.length === 0 || path.isAbsolute(relative)) {
+    fail("fixture_source_path_invalid", "repository_path must be a non-empty relative path", "repository_path");
+  }
+  const root = repositoryRoot();
+  const target = path.resolve(root, relative);
+  const local = path.relative(root, target);
+  if (local !== relative || local.startsWith(`..${path.sep}`)) {
+    fail("fixture_source_path_invalid", "repository_path must remain normalized inside the repository", relative);
+  }
+  let current = root;
+  for (const segment of relative.split("/")) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) fail("fixture_source_missing", "fixture source does not exist", relative);
+    if (fs.lstatSync(current).isSymbolicLink()) fail("fixture_source_symlink", "fixture source must not traverse a symlink", relative);
+  }
+  if (!fs.lstatSync(target).isFile()) fail("fixture_source_type_invalid", "fixture source must be a regular file", relative);
+  return target;
+}
+
+function verifyProjectedSource(seed) {
+  if (!Object.hasOwn(seed, "repository_path")) return;
+  const expected = seed.canonical_sha256;
+  if (typeof expected !== "string" || !/^[a-f0-9]{64}$/.test(expected)) {
+    fail("fixture_source_digest_invalid", "canonical_sha256 must be 64 lowercase hex characters", seed.stable_ref);
+  }
+  const file = safeRepositoryFile(seed.repository_path);
+  let value;
+  try {
+    value = parseStrictJson(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    fail("fixture_source_json_invalid", error instanceof Error ? error.message : String(error), seed.repository_path);
+  }
+  const actual = hashCanonical(value).slice("sha256:".length);
+  if (actual !== expected) fail("fixture_source_digest_mismatch", "projected source changed; create a new registry version", seed.repository_path);
+}
+
+function versionedGeneric(seed) {
+  const payload = structuredClone(seed);
+  payload.schema_version ??= "1.0";
+  delete payload.version_id;
+  delete payload.versionId;
+  const stableRef = createStableRef(payload.stable_ref);
+  return deepFreeze({ ...payload, version_id: createVersionId({ stableRef, payload }) });
+}
+
+function materialize(seed, sourceRecords = new Map()) {
+  verifyProjectedSource(seed);
+  switch (seed.record_kind) {
+    case "claim": return createClaim(seed);
+    case "evidence_link": return createEvidenceLink(seed);
+    case "validation_report": return createValidationReport(seed);
+    case "governance_decision": return createGovernanceDecision(seed);
+    case "policy_disposition": return createPolicyDisposition(seed);
+    case "operation": return defineOperation(seed);
+    case "execution_receipt": {
+      const source = sourceRecords.get(seed.fixture_record_ref);
+      if (!source || source.record_kind !== "executable_fixture") {
+        fail("fixture_receipt_source_missing", "execution receipt must reference an executable fixture", seed.stable_ref);
+      }
+      if (seed.fixture_version_id !== undefined && seed.fixture_version_id !== source.version_id) {
+        fail("fixture_receipt_version_mismatch", "execution receipt fixture_version_id must match the executable fixture VersionID", seed.stable_ref);
+      }
+      return versionedGeneric({ ...seed, fixture_version_id: source.version_id });
+    }
+    default: return versionedGeneric(seed);
+  }
+}
+
+function validateSeed(seed) {
+  if (!plainObject(seed)) fail("fixture_registry_invalid", "registry source must contain an object");
+  if (seed.schema_version !== "1.0") fail("fixture_schema_version_unsupported", "registry schema_version must be 1.0", "schema_version");
+  if (seed.fixture_ref !== FIXTURE_MANIFEST_REF) fail("fixture_manifest_ref_invalid", `fixture_ref must be ${FIXTURE_MANIFEST_REF}`, "fixture_ref");
+  if (!Array.isArray(seed.records)) fail("fixture_records_required", "registry records must be an array", "records");
+  const refs = seed.records.map((record, index) => {
+    if (!plainObject(record)) fail("fixture_record_invalid", "registry records must be objects", `records/${index}`);
+    try { return createStableRef(record.stable_ref); } catch (error) {
+      fail(error.code ?? "fixture_stable_ref_invalid", error.message, `records/${index}/stable_ref`);
+    }
+  });
+  if (new Set(refs).size !== refs.length) fail("fixture_stable_ref_duplicate", "fixture StableRefs must be unique", "records");
+  if (!refs.includes(EDITORIAL_PROFILE_REF)) fail("fixture_editorial_profile_missing", `fixture must contain ${EDITORIAL_PROFILE_REF}`, "records");
+}
+
+export function loadRegistrySeed(source = REGISTRY_SOURCE_URL) {
+  const file = source instanceof URL ? fileURLToPath(source) : path.resolve(String(source));
+  if (!fs.existsSync(file) || fs.lstatSync(file).isSymbolicLink() || !fs.lstatSync(file).isFile()) {
+    fail("fixture_registry_file_invalid", "registry source must be a regular non-symlink file", file);
+  }
+  let seed;
+  try { seed = parseStrictJson(fs.readFileSync(file, "utf8")); } catch (error) {
+    fail("fixture_registry_json_invalid", error instanceof Error ? error.message : String(error), file);
+  }
+  validateSeed(seed);
+  return deepFreeze(seed);
+}
+
+export function createAgentNativeFixture(input = {}) {
+  const seed = input.seed ?? loadRegistrySeed(input.source);
+  validateSeed(seed);
+  const materializedSources = new Map(seed.records
+    .filter((record) => record.record_kind !== "execution_receipt")
+    .map((record) => materialize(record))
+    .map((record) => [record.stable_ref, record]));
+  const records = seed.records.map((record) => record.record_kind === "execution_receipt"
+    ? materialize(record, materializedSources)
+    : materializedSources.get(record.stable_ref)).sort((left, right) => (
+    left.stable_ref < right.stable_ref ? -1 : left.stable_ref > right.stable_ref ? 1 : 0
+  ));
+  const entries = records.map((record) => ({
+    content_sha256: hashCanonical(record).slice("sha256:".length),
+    stable_ref: record.stable_ref,
+    version_id: record.version_id,
+  }));
+  const manifest = createManifest({ manifest_ref: seed.fixture_ref, entries, schema_version: seed.schema_version });
+  return deepFreeze({ fixture_ref: seed.fixture_ref, manifest, records, schema_version: seed.schema_version });
+}
+
+export const agentNativeFixture = createAgentNativeFixture();

--- a/scripts/agent-native/identity.mjs
+++ b/scripts/agent-native/identity.mjs
@@ -1,0 +1,184 @@
+import { deepFreeze, hashCanonical } from "./canonical-json.mjs";
+
+export class IdentityError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "IdentityError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const STABLE_REF_KINDS = Object.freeze([
+  "profile", "artifact", "claim", "evidence", "validation", "governance", "operation", "task", "proposal", "view",
+  "agent", "validator", "observer", "governor", "capability", "receipt", "run", "effect", "context", "manifest", "policy", "connector", "event", "snapshot", "source", "skill",
+]);
+const KIND_SET = new Set(STABLE_REF_KINDS);
+
+function fail(code, message, path) {
+  throw new IdentityError(code, message, path);
+}
+
+function inputValue(input, names) {
+  if (typeof input === "string") return input;
+  if (!input || typeof input !== "object") return undefined;
+  for (const name of names) if (Object.hasOwn(input, name)) return input[name];
+  return undefined;
+}
+
+function requireRef(value, path = "stable_ref") {
+  if (typeof value !== "string") fail("stable_ref_required", "StableRef must be a string", path);
+  const match = /^sg:([a-z0-9-]+)\/([a-z0-9]+(?:-[a-z0-9]+)*)$/.exec(value);
+  if (!match || !KIND_SET.has(match[1])) fail("stable_ref_invalid", "StableRef must match the governed sg:<kind>/<kebab-id> grammar", path);
+  return { stable_ref: value, kind: match[1], id: match[2] };
+}
+
+export function createStableRef(input) {
+  const value = typeof input === "string" ? input : undefined;
+  if (value) return requireRef(value).stable_ref;
+  const kind = inputValue(input, ["kind", "namespace", "type"]);
+  const id = inputValue(input, ["id", "opaque_id", "opaqueId"]);
+  if (typeof kind !== "string" || typeof id !== "string") fail("stable_ref_parts_required", "createStableRef requires kind and id");
+  if (!KIND_SET.has(kind) || !KEBAB.test(kind)) fail("stable_ref_kind_invalid", `unsupported StableRef kind ${kind}`, "kind");
+  if (!KEBAB.test(id)) fail("stable_ref_id_invalid", `StableRef id must be kebab-case: ${id}`, "id");
+  return `sg:${kind}/${id}`;
+}
+
+export const stableRef = createStableRef;
+
+export function parseStableRef(input) {
+  const value = inputValue(input, ["stable_ref", "stableRef", "ref", "value"]);
+  const parsed = requireRef(value, "stable_ref");
+  return deepFreeze({ ...parsed, stableRef: parsed.stable_ref, opaque_id: parsed.id, opaqueId: parsed.id });
+}
+
+export const parseRef = parseStableRef;
+
+function payloadOf(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input;
+  if (Object.hasOwn(input, "payload")) return input.payload;
+  if (Object.hasOwn(input, "version_payload")) return input.version_payload;
+  if (Object.hasOwn(input, "versionPayload")) return input.versionPayload;
+  return input;
+}
+
+function versionContent(stable_ref, payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { stable_ref, content: payload };
+  }
+  const copy = { ...payload };
+  delete copy.stable_ref;
+  delete copy.stableRef;
+  delete copy.ref;
+  delete copy.version_id;
+  delete copy.versionId;
+  return { stable_ref, ...copy };
+}
+
+function digestPayload(stable_ref, payload) {
+  return hashCanonical(versionContent(stable_ref, payload)).replace(/^sha256:/, "");
+}
+
+export function createVersionId(input) {
+  const payload = payloadOf(input);
+  const ref = inputValue(input, ["stable_ref", "stableRef", "ref"]) ?? (payload && typeof payload === "object" ? inputValue(payload, ["stable_ref", "stableRef", "ref"]) : undefined);
+  const stable_ref = createStableRef(ref);
+  return `${stable_ref}@sha256:${digestPayload(stable_ref, payload)}`;
+}
+
+export const versionId = createVersionId;
+
+const VERSION_RE = /^(sg:[a-z0-9-]+\/[a-z0-9]+(?:-[a-z0-9]+)*)@sha256:([a-f0-9]{64})$/;
+
+export function parseVersionId(input) {
+  const value = inputValue(input, ["version_id", "versionId", "id", "value"]);
+  if (typeof value !== "string") fail("version_id_required", "VersionID must be a string", "version_id");
+  const match = VERSION_RE.exec(value);
+  if (!match) fail("version_id_invalid", "VersionID must be StableRef@sha256:<64 lowercase hex>", "version_id");
+  const parsedRef = requireRef(match[1]);
+  const expectedRef = typeof input === "string" ? undefined : inputValue(input, ["stable_ref", "stableRef", "ref"]);
+  if (expectedRef !== undefined && createStableRef(expectedRef) !== parsedRef.stable_ref) fail("version_ref_mismatch", "VersionID StableRef does not match the supplied StableRef");
+  const payload = input && typeof input === "object" ? (Object.hasOwn(input, "payload") ? input.payload : Object.hasOwn(input, "version_payload") ? input.version_payload : undefined) : undefined;
+  if (payload !== undefined && digestPayload(parsedRef.stable_ref, payload) !== match[2]) fail("version_digest_mismatch", "VersionID digest does not match the supplied payload", "version_id");
+  return deepFreeze({ version_id: value, versionId: value, stable_ref: parsedRef.stable_ref, stableRef: parsedRef.stable_ref, digest: match[2], hash_suite: "sha256" });
+}
+
+export const parseVersion = parseVersionId;
+
+function normalizeEntry(entry, index) {
+  const hasIdentity = entry && typeof entry === "object" && (Object.hasOwn(entry, "stable_ref") || Object.hasOwn(entry, "stableRef") || Object.hasOwn(entry, "ref"));
+  const source = hasIdentity ? entry : entry?.object ?? entry?.record ?? entry?.value ?? entry;
+  if (!source || typeof source !== "object") fail("manifest_entry_invalid", "manifest entries must be objects", `/entries/${index}`);
+  const stable_ref = createStableRef(inputValue(source, ["stable_ref", "stableRef", "ref"]));
+  const version_id = inputValue(source, ["version_id", "versionId"]);
+  const hasContent = Object.hasOwn(source, "content");
+  const content = hasContent ? source.content : undefined;
+  if (hasContent && content && typeof content === "object" && !Array.isArray(content)) {
+    const contentRef = inputValue(content, ["stable_ref", "stableRef", "ref"]);
+    if (contentRef !== undefined && createStableRef(contentRef) !== stable_ref) {
+      fail("manifest_content_ref_mismatch", "manifest entry StableRef does not match its supplied content", `/entries/${index}/content/stable_ref`);
+    }
+    const contentVersion = inputValue(content, ["version_id", "versionId"]);
+    if (contentVersion !== undefined && contentVersion !== version_id) {
+      fail("manifest_content_version_mismatch", "manifest entry VersionID does not match its supplied content", `/entries/${index}/content/version_id`);
+    }
+  }
+  parseVersionId({ version_id, stable_ref, ...(hasContent ? { payload: content } : {}) });
+  let content_sha256 = inputValue(source, ["content_sha256", "contentHash", "sha256"]);
+  const expectedContentSha = hasContent ? hashCanonical(content).replace(/^sha256:/, "") : undefined;
+  if (content_sha256 === undefined && hasContent) content_sha256 = expectedContentSha;
+  if (typeof content_sha256 !== "string" || !/^[a-f0-9]{64}$/.test(content_sha256)) fail("manifest_content_hash_invalid", "manifest entry content_sha256 must be 64 lowercase hex characters", `/entries/${index}/content_sha256`);
+  if (hasContent && content_sha256 !== expectedContentSha) fail("manifest_content_digest_mismatch", "manifest entry content_sha256 does not match its supplied content", `/entries/${index}/content_sha256`);
+  return { stable_ref, version_id, content_sha256, ...(hasContent ? { content: structuredClone(content) } : {}) };
+}
+
+function manifestBody(manifest, includeVersion) {
+  const body = { schema_version: manifest.schema_version, manifest_ref: manifest.manifest_ref, entries: manifest.entries };
+  if (includeVersion) body.version_id = manifest.version_id;
+  return body;
+}
+
+export function createManifest(input = {}) {
+  const manifest_ref = createStableRef(inputValue(input, ["manifest_ref", "manifestRef", "ref"]));
+  const rawEntries = inputValue(input, ["entries", "objects", "records"]) ?? [];
+  if (!Array.isArray(rawEntries)) fail("manifest_entries_required", "manifest entries must be an array", "entries");
+  const entries = rawEntries.map(normalizeEntry).sort((left, right) => left.stable_ref < right.stable_ref ? -1 : left.stable_ref > right.stable_ref ? 1 : 0);
+  if (new Set(entries.map((entry) => entry.stable_ref)).size !== entries.length) fail("manifest_entry_duplicate", "manifest entries must have unique StableRefs", "entries");
+  const base = { schema_version: input.schema_version ?? input.schemaVersion ?? "1.0", manifest_ref, entries };
+  const version_id = `${manifest_ref}@sha256:${hashCanonical(base).replace(/^sha256:/, "")}`;
+  const sha256 = hashCanonical({ ...base, version_id }).replace(/^sha256:/, "");
+  return deepFreeze({ ...base, version_id, sha256 });
+}
+
+export const makeManifest = createManifest;
+
+export function verifyManifest(input) {
+  const manifest = input?.manifest ?? input;
+  const failures = [];
+  if (!manifest || typeof manifest !== "object") return { ok: false, failures: [{ code: "manifest_required", message: "manifest must be an object" }] };
+  let ref;
+  try { ref = createStableRef(manifest.manifest_ref); } catch (error) { failures.push({ code: error.code ?? "manifest_ref_invalid", message: error.message, path: "manifest_ref" }); }
+  const entries = manifest.entries;
+  if (!Array.isArray(entries)) failures.push({ code: "manifest_entries_required", message: "manifest entries must be an array", path: "entries" });
+  else {
+    const refs = [];
+    for (let index = 0; index < entries.length; index += 1) {
+      for (const alias of ["stableRef", "ref", "versionId", "contentHash"]) {
+        if (Object.hasOwn(entries[index] ?? {}, alias)) failures.push({ code: "manifest_alias_forbidden", message: `${alias} is not a canonical manifest entry key`, path: `/entries/${index}/${alias}` });
+      }
+      try { refs.push(normalizeEntry(entries[index], index).stable_ref); } catch (error) { failures.push({ code: error.code ?? "manifest_entry_invalid", message: error.message, path: error.path ?? `/entries/${index}` }); }
+    }
+    if (new Set(refs).size !== refs.length) failures.push({ code: "manifest_entry_duplicate", message: "manifest entries must be unique", path: "entries" });
+    if (refs.some((entry, index) => index > 0 && refs[index - 1] > entry)) failures.push({ code: "manifest_entries_unsorted", message: "manifest entries must be sorted by StableRef", path: "entries" });
+  }
+  if (failures.length === 0) {
+    const expectedVersion = `${ref}@sha256:${hashCanonical(manifestBody(manifest, false)).replace(/^sha256:/, "")}`;
+    const expectedSha = hashCanonical(manifestBody({ ...manifest, version_id: expectedVersion }, true)).replace(/^sha256:/, "");
+    if (manifest.version_id !== expectedVersion) failures.push({ code: "manifest_version_mismatch", message: "manifest VersionID does not match canonical entries", path: "version_id" });
+    if (manifest.sha256 !== expectedSha) failures.push({ code: "manifest_digest_mismatch", message: "manifest sha256 does not match canonical bytes", path: "sha256" });
+  }
+  return deepFreeze({ ok: failures.length === 0, failures });
+}
+
+export const validateManifest = verifyManifest;

--- a/scripts/agent-native/immutable-store.mjs
+++ b/scripts/agent-native/immutable-store.mjs
@@ -1,0 +1,102 @@
+import { canonicalize, cloneAndFreeze, deepFreeze } from "./canonical-json.mjs";
+import { parseStableRef, parseVersionId } from "./identity.mjs";
+
+export class ImmutableStoreError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "ImmutableStoreError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+function fail(code, message, path) {
+  throw new ImmutableStoreError(code, message, path);
+}
+
+function recordRef(record) {
+  const stable_ref = record?.stable_ref ?? record?.stableRef;
+  const version_id = record?.version_id ?? record?.versionId;
+  if (typeof stable_ref !== "string") fail("store_stable_ref_required", "append requires a StableRef", "stable_ref");
+  if (typeof version_id !== "string") fail("store_version_id_required", "append requires a VersionID", "version_id");
+  parseStableRef(stable_ref);
+  parseVersionId({ version_id, stable_ref, payload: record });
+  return { stable_ref, version_id };
+}
+
+function cloneRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail("store_record_invalid", "append requires an object record");
+  try { canonicalize(value); } catch (error) { fail(error.code ?? "store_record_invalid", error.message); }
+  return cloneAndFreeze(value);
+}
+
+function compare(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+/** Create an append-only in-memory store exposing only frozen copies. */
+export function createImmutableStore(input = {}) {
+  const byVersion = new Map();
+  const byStableRef = new Map();
+  const initial = input.entries ?? input.records ?? [];
+  if (!Array.isArray(initial)) fail("store_entries_required", "store entries must be an array", "entries");
+
+  const append = (candidate) => {
+    const value = !candidate?.stable_ref && !candidate?.stableRef
+      ? (candidate?.object ?? candidate?.record ?? candidate?.value ?? candidate)
+      : candidate;
+    const { stable_ref, version_id } = recordRef(value);
+    const frozen = cloneRecord(value);
+    const existing = byVersion.get(version_id);
+    if (existing) {
+      if (canonicalize(existing) !== canonicalize(frozen)) fail("store_version_conflict", "VersionID is already bound to different immutable bytes", "version_id");
+      return existing;
+    }
+    byVersion.set(version_id, frozen);
+    const versions = byStableRef.get(stable_ref) ?? [];
+    byStableRef.set(stable_ref, [...versions, frozen]);
+    return frozen;
+  };
+
+  for (const entry of initial) append(entry);
+
+  const entries = () => [...byVersion.values()].sort((left, right) => compare(left.stable_ref ?? left.stableRef, right.stable_ref ?? right.stableRef) || compare(left.version_id ?? left.versionId, right.version_id ?? right.versionId));
+  const resolve = (reference) => {
+    const value = typeof reference === "string" ? reference : reference?.stable_ref ?? reference?.stableRef ?? reference?.version_id ?? reference?.versionId;
+    if (typeof value !== "string") fail("store_reference_required", "resolve requires a StableRef or VersionID");
+    if (value.includes("@sha256:")) {
+      parseVersionId(value);
+      return byVersion.get(value);
+    }
+    try { parseStableRef(value); } catch (error) { fail(error.code ?? "store_reference_invalid", error.message); }
+    const versions = byStableRef.get(value) ?? [];
+    return versions.length === 0 ? undefined : versions[versions.length - 1];
+  };
+
+  const snapshot = () => deepFreeze({ entries: entries(), size: byVersion.size });
+  return deepFreeze({
+    append,
+    get: resolve,
+    resolve,
+    has: (reference) => resolve(reference) !== undefined,
+    entries: snapshot,
+    listEntries: snapshot,
+    all: snapshot,
+    snapshot,
+    get size() { return byVersion.size; },
+  });
+}
+
+export const createStore = createImmutableStore;
+
+export function appendImmutable(input) {
+  if (!input || typeof input !== "object") fail("store_input_required", "appendImmutable requires {store, record}");
+  const store = input.store ?? input.target;
+  const record = input.record ?? input.object ?? input.value;
+  if (!store || typeof store.append !== "function") fail("store_required", "appendImmutable requires an immutable store", "store");
+  return store.append(record);
+}
+
+export const appendObject = appendImmutable;

--- a/scripts/agent-native/knowledge.mjs
+++ b/scripts/agent-native/knowledge.mjs
@@ -1,0 +1,168 @@
+import { createVersionId } from "./identity.mjs";
+import { deepFreeze } from "./canonical-json.mjs";
+
+const CONTROL_KEYS = new Set(["schema_version", "record_kind", "kind", "type", "version_id", "versionId"]);
+
+function clone(value) {
+  return value === undefined ? value : structuredClone(value);
+}
+
+function own(input, ...keys) {
+  for (const key of keys) if (Object.hasOwn(input, key)) return input[key];
+  return undefined;
+}
+
+function requiredObject(input, name) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError(`${name} expects an object parameter`);
+  return input;
+}
+
+function stableRefOf(input, name) {
+  const stableRef = own(input, "stable_ref", "stableRef");
+  if (typeof stableRef !== "string" || stableRef.length === 0) throw new TypeError(`${name}.stable_ref is required`);
+  return stableRef;
+}
+
+function canonicalFields(input, stableRef, recordKind) {
+  const fields = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!CONTROL_KEYS.has(key) && key !== "stable_ref" && key !== "stableRef") fields[key] = clone(value);
+  }
+  return { schema_version: "1.0", record_kind: recordKind, stable_ref: stableRef, ...fields };
+}
+
+function createRecord(input, recordKind, name) {
+  const source = requiredObject(input, name);
+  const stableRef = stableRefOf(source, name);
+  const record = canonicalFields(source, stableRef, recordKind);
+  const versionId = createVersionId({ stableRef, payload: record });
+  if (typeof versionId !== "string" || !/^sg:[^@]+@sha256:[a-f0-9]{64}$/.test(versionId)) {
+    throw new TypeError(`${name} received an invalid VersionID from the identity kernel`);
+  }
+  const supplied = own(source, "version_id", "versionId");
+  if (supplied !== undefined && supplied !== versionId) throw new TypeError(`${name}.version_id does not match its content`);
+  return deepFreeze({ ...record, version_id: versionId });
+}
+
+export function createClaim(input) {
+  return createRecord(input, "claim", "createClaim");
+}
+
+export const makeClaim = createClaim;
+
+export function createEvidenceLink(input) {
+  const source = requiredObject(input, "createEvidenceLink");
+  const normalized = { ...source };
+  const aliases = [
+    ["claim_ref", "claimRef"],
+    ["claim_version", "claimVersion"],
+    ["source_ref", "sourceRef"],
+    ["source_version", "sourceVersion"],
+    ["independence_group", "independenceGroup"],
+  ];
+  for (const [canonical, alias] of aliases) {
+    if (!Object.hasOwn(normalized, canonical) && Object.hasOwn(normalized, alias)) normalized[canonical] = normalized[alias];
+    delete normalized[alias];
+  }
+  const polarity = own(normalized, "polarity", "stance");
+  if (typeof polarity === "string") normalized.polarity = polarity.toUpperCase();
+  return createRecord(normalized, "evidence_link", "createEvidenceLink");
+}
+
+export const makeEvidenceLink = createEvidenceLink;
+export const createEvidence = createEvidenceLink;
+export const makeEvidence = createEvidenceLink;
+
+export function createAttestation(input) {
+  const source = requiredObject(input, "createAttestation");
+  const normalized = { ...source };
+  if (!Object.hasOwn(normalized, "claim_ref") && Object.hasOwn(normalized, "claimRef")) normalized.claim_ref = normalized.claimRef;
+  if (!Object.hasOwn(normalized, "claim_version") && Object.hasOwn(normalized, "claimVersion")) normalized.claim_version = normalized.claimVersion;
+  if (typeof normalized.polarity === "string") normalized.polarity = normalized.polarity.toUpperCase();
+  delete normalized.claimRef;
+  delete normalized.claimVersion;
+  return createRecord(normalized, "attestation", "createAttestation");
+}
+
+export const makeAttestation = createAttestation;
+
+export function createValidationReport(input) {
+  const source = requiredObject(input, "createValidationReport");
+  const normalized = { ...source };
+  if (!Object.hasOwn(normalized, "claim_ref") && Object.hasOwn(normalized, "claimRef")) normalized.claim_ref = normalized.claimRef;
+  if (!Object.hasOwn(normalized, "claim_version") && Object.hasOwn(normalized, "claimVersion")) normalized.claim_version = normalized.claimVersion;
+  if (!Object.hasOwn(normalized, "validator_version") && Object.hasOwn(normalized, "validatorVersion")) normalized.validator_version = normalized.validatorVersion;
+  if (typeof normalized.status === "string") normalized.status = normalized.status.toUpperCase();
+  delete normalized.claimRef;
+  delete normalized.claimVersion;
+  delete normalized.validatorVersion;
+  return createRecord(normalized, "validation_report", "createValidationReport");
+}
+
+export const makeValidationReport = createValidationReport;
+
+export function createGovernanceDecision(input) {
+  const source = requiredObject(input, "createGovernanceDecision");
+  const normalized = { ...source };
+  if (!Object.hasOwn(normalized, "claim_ref") && Object.hasOwn(normalized, "claimRef")) normalized.claim_ref = normalized.claimRef;
+  if (!Object.hasOwn(normalized, "claim_version") && Object.hasOwn(normalized, "claimVersion")) normalized.claim_version = normalized.claimVersion;
+  if (!Object.hasOwn(normalized, "policy_version") && Object.hasOwn(normalized, "policyVersion")) normalized.policy_version = normalized.policyVersion;
+  if (typeof normalized.decision === "string") normalized.decision = normalized.decision.toUpperCase();
+  delete normalized.claimRef;
+  delete normalized.claimVersion;
+  delete normalized.policyVersion;
+  return createRecord(normalized, "governance_decision", "createGovernanceDecision");
+}
+
+export const makeGovernanceDecision = createGovernanceDecision;
+
+export function createPolicyDisposition(input) {
+  const source = requiredObject(input, "createPolicyDisposition");
+  const normalized = { ...source };
+  if (!Object.hasOwn(normalized, "claim_ref") && Object.hasOwn(normalized, "claimRef")) normalized.claim_ref = normalized.claimRef;
+  if (!Object.hasOwn(normalized, "claim_version") && Object.hasOwn(normalized, "claimVersion")) normalized.claim_version = normalized.claimVersion;
+  if (!Object.hasOwn(normalized, "policy_version") && Object.hasOwn(normalized, "policyVersion")) normalized.policy_version = normalized.policyVersion;
+  delete normalized.claimRef;
+  delete normalized.claimVersion;
+  delete normalized.policyVersion;
+  return createRecord(normalized, "policy_disposition", "createPolicyDisposition");
+}
+
+export const makePolicyDisposition = createPolicyDisposition;
+
+function linksFrom(input) {
+  if (Array.isArray(input)) return input;
+  const source = requiredObject(input, "aggregateEvidence");
+  return own(source, "evidence_links", "evidenceLinks", "evidence") ?? [];
+}
+
+function polarityOf(link) {
+  const value = own(link, "polarity", "stance", "direction");
+  if (typeof value !== "string") return undefined;
+  const polarity = value.toUpperCase();
+  if (["SUPPORT", "SUPPORTED", "POSITIVE", "FOR"].includes(polarity)) return "SUPPORT";
+  if (["REFUTE", "REFUTED", "NEGATIVE", "AGAINST", "CONTRADICT"].includes(polarity)) return "REFUTE";
+  return undefined;
+}
+
+export function aggregateEvidence(input) {
+  const source = Array.isArray(input) ? {} : requiredObject(input, "aggregateEvidence");
+  const links = linksFrom(input).filter((link) => link && typeof link === "object");
+  const support = links.filter((link) => polarityOf(link) === "SUPPORT");
+  const refute = links.filter((link) => polarityOf(link) === "REFUTE");
+  const state = support.length && refute.length ? "BOTH" : support.length ? "SUPPORTED" : refute.length ? "REFUTED" : "NEITHER";
+  const groups = (items) => [...new Set(items.map((link) => own(link, "independence_group", "independenceGroup")).filter((value) => typeof value === "string"))].sort();
+  return deepFreeze({
+    claim_ref: own(source.claim, "stable_ref", "stableRef") ?? own(source, "claim_ref", "claimRef"),
+    claim_version: own(source.claim, "version_id", "versionId") ?? own(source, "claim_version", "claimVersion"),
+    state,
+    evidence_state: state,
+    support_count: support.length,
+    refute_count: refute.length,
+    support_groups: groups(support),
+    refute_groups: groups(refute),
+    evidence_links: links,
+  });
+}
+
+export const aggregateEvidenceState = aggregateEvidence;

--- a/scripts/agent-native/learning-records.mjs
+++ b/scripts/agent-native/learning-records.mjs
@@ -1,0 +1,244 @@
+import { deepFreeze } from "./canonical-json.mjs";
+import { createStableRef, createVersionId, parseStableRef, parseVersionId } from "./identity.mjs";
+
+const CONTROL_KEYS = new Set([
+  "record_kind", "schema_version", "stable_ref", "stableRef", "version_id", "versionId",
+]);
+const PASSING = new Set(["PASS", "PASSED", "VALID", "VALIDATED", "OK"]);
+
+export class LearningError extends TypeError {
+  constructor(code, message, path = "") {
+    super(message);
+    this.name = "LearningError";
+    this.code = code;
+    if (path) this.path = path;
+  }
+}
+
+export function failLearning(code, message, path = "") {
+  throw new LearningError(code, message, path);
+}
+
+export function own(value, ...keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key)) return value[key];
+  return undefined;
+}
+
+export function learningObject(value, path) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    failLearning("learning_object_required", `${path} expects an object`, path);
+  }
+  return value;
+}
+
+export function copyLearning(value) {
+  if (value === undefined || value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => (item === undefined ? null : copyLearning(item)));
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, copyLearning(item)]),
+  );
+}
+
+export function compactLearning(fields) {
+  return Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined));
+}
+
+export function textLearning(value, path) {
+  if (typeof value !== "string" || value.trim() === "") {
+    failLearning("learning_text_required", `${path} must be a non-empty string`, path);
+  }
+  return value;
+}
+
+export function stableLearningRef(value, path, fallback) {
+  try {
+    return createStableRef(value ?? fallback);
+  } catch (error) {
+    failLearning("learning_stable_ref_invalid", error instanceof Error ? error.message : String(error), path);
+  }
+}
+
+function canonicalFields(source) {
+  return Object.fromEntries(
+    Object.entries(source)
+      .filter(([key, value]) => !CONTROL_KEYS.has(key) && value !== undefined)
+      .map(([key, value]) => [key, copyLearning(value)]),
+  );
+}
+
+export function makeLearningRecord(input, stableRef, recordKind, fields) {
+  const source = learningObject(input, recordKind);
+  if (source.record_kind !== undefined && source.record_kind !== recordKind) {
+    failLearning("learning_record_kind_invalid", `${recordKind} cannot be created from ${source.record_kind}`, "record_kind");
+  }
+  if (source.schema_version !== undefined && source.schema_version !== "1.0") {
+    failLearning("learning_schema_version_invalid", "learning records require schema_version 1.0", "schema_version");
+  }
+  const stable_ref = stableLearningRef(stableRef, "stable_ref");
+  const payload = {
+    schema_version: "1.0",
+    record_kind: recordKind,
+    stable_ref,
+    ...Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined)),
+  };
+  const version_id = createVersionId({ stable_ref, payload });
+  const supplied = own(source, "version_id", "versionId");
+  if (supplied !== undefined && supplied !== version_id) {
+    failLearning("learning_version_mismatch", "version_id does not match immutable content", "version_id");
+  }
+  return deepFreeze({ ...copyLearning(payload), version_id });
+}
+
+export function assertLearningRecord(value, recordKind, path = recordKind) {
+  const source = learningObject(value, path);
+  if (Object.hasOwn(source, "stableRef") || Object.hasOwn(source, "versionId")) {
+    failLearning("learning_record_alias_forbidden", `${path} must use canonical identity keys`, path);
+  }
+  if (source.record_kind !== recordKind) {
+    failLearning("learning_record_kind_invalid", `${path} must be ${recordKind}`, `${path}.record_kind`);
+  }
+  if (source.schema_version !== "1.0") {
+    failLearning("learning_schema_version_invalid", `${path} must use schema_version 1.0`, `${path}.schema_version`);
+  }
+  const stable_ref = stableLearningRef(own(source, "stable_ref", "stableRef"), `${path}.stable_ref`);
+  const version_id = own(source, "version_id", "versionId");
+  const payload = copyLearning(source);
+  delete payload.version_id;
+  delete payload.versionId;
+  try {
+    parseVersionId({ payload, stable_ref, version_id });
+  } catch (error) {
+    failLearning(
+      "learning_record_version_invalid",
+      `${path} VersionID does not bind its canonical bytes: ${error instanceof Error ? error.message : String(error)}`,
+      `${path}.version_id`,
+    );
+  }
+  return deepFreeze(copyLearning(source));
+}
+
+function canonicalAliases(source) {
+  const fields = canonicalFields(source);
+  const aliases = [
+    ["independence_group", "independentGroup"],
+    ["proposal_ref", "proposalRef"],
+    ["proposal_version_id", "proposalVersionId"],
+    ["receipt_id", "receiptId"],
+    ["source_ref", "sourceRef"],
+    ["source_version_id", "sourceVersionId"],
+  ];
+  for (const [canonical, alias] of aliases) {
+    if (fields[canonical] === undefined && fields[alias] !== undefined) fields[canonical] = fields[alias];
+    delete fields[alias];
+  }
+  return fields;
+}
+
+function applyBindings(fields, bindings, path) {
+  for (const [key, expected] of Object.entries(bindings)) {
+    if (fields[key] !== undefined && fields[key] !== expected) {
+      failLearning("learning_link_mismatch", `${path}.${key} does not match its governed parent`, `${path}.${key}`);
+    }
+    fields[key] = expected;
+  }
+  return fields;
+}
+
+export function makeEvidenceRecords(values, options) {
+  if (!Array.isArray(values) || values.length === 0) {
+    failLearning("learning_evidence_required", "at least one evidence record is required", options.path);
+  }
+  return values.map((item, index) => {
+    const path = `${options.path}/${index}`;
+    const source = learningObject(item, path);
+    const stableRef = stableLearningRef(
+      own(source, "stable_ref", "stableRef"),
+      `${path}.stable_ref`,
+      `sg:evidence/${options.slug}-${index + 1}`,
+    );
+    if (parseStableRef(stableRef).kind !== "evidence") {
+      failLearning("learning_record_kind_invalid", `${path}.stable_ref must use sg:evidence/...`, `${path}.stable_ref`);
+    }
+    const fields = applyBindings(canonicalAliases(source), options.bindings ?? {}, path);
+    return makeLearningRecord(source, stableRef, "evidence_link", fields);
+  });
+}
+
+export function makeValidationRecord(value, options) {
+  const source = learningObject(value, options.path);
+  const fields = canonicalAliases(source);
+  if (fields.validator === undefined && fields.validator_actor !== undefined) fields.validator = fields.validator_actor;
+  if (fields.validator_version === undefined && fields.version !== undefined) fields.validator_version = fields.version;
+  delete fields.validator_actor;
+  delete fields.version;
+  fields.validator = textLearning(fields.validator, `${options.path}.validator`).trim();
+  const status = textLearning(fields.status, `${options.path}.status`).toUpperCase();
+  if (!PASSING.has(status)) {
+    failLearning("learning_validation_not_passed", `${options.path} must have a passing status`, `${options.path}.status`);
+  }
+  fields.status = status;
+  applyBindings(fields, options.bindings ?? {}, options.path);
+  if (parseStableRef(options.stableRef).kind !== "validation") {
+    failLearning("learning_record_kind_invalid", `${options.path}.stable_ref must use sg:validation/...`, `${options.path}.stable_ref`);
+  }
+  return makeLearningRecord(source, options.stableRef, "validation_report", fields);
+}
+
+export function assertLink(record, key, expected, path) {
+  if (record[key] !== expected) {
+    failLearning("learning_link_mismatch", `${path}.${key} must bind ${expected}`, `${path}.${key}`);
+  }
+}
+
+export function assertEvidenceRecords(values, bindings, path = "evidence") {
+  if (!Array.isArray(values) || values.length === 0) {
+    failLearning("learning_evidence_required", `${path} requires at least one evidence record`, path);
+  }
+  return values.map((value, index) => {
+    const record = assertLearningRecord(value, "evidence_link", `${path}/${index}`);
+    if (parseStableRef(record.stable_ref).kind !== "evidence") {
+      failLearning("learning_record_kind_invalid", `${path}/${index} must use sg:evidence/...`, `${path}/${index}/stable_ref`);
+    }
+    for (const [key, expected] of Object.entries(bindings ?? {})) assertLink(record, key, expected, `${path}/${index}`);
+    return record;
+  });
+}
+
+export function assertValidationRecord(value, bindings, path = "validation") {
+  const record = assertLearningRecord(value, "validation_report", path);
+  if (parseStableRef(record.stable_ref).kind !== "validation") {
+    failLearning("learning_record_kind_invalid", `${path} must use sg:validation/...`, `${path}.stable_ref`);
+  }
+  if (!PASSING.has(String(record.status).toUpperCase())) {
+    failLearning("learning_validation_not_passed", `${path} must have a passing status`, `${path}.status`);
+  }
+  const validator = textLearning(record.validator, `${path}.validator`);
+  if (validator !== validator.trim()) {
+    failLearning("learning_actor_invalid", `${path}.validator must be canonical`, `${path}.validator`);
+  }
+  for (const [key, expected] of Object.entries(bindings ?? {})) assertLink(record, key, expected, path);
+  return record;
+}
+
+export function nextLearningRegistry(registry, targetRef, versionId) {
+  if (registry === undefined) return undefined;
+  const source = learningObject(registry, "registry");
+  const entries = own(source, "entries");
+  if (!Array.isArray(entries)) {
+    failLearning("learning_registry_invalid", "registry.entries must be an array", "registry.entries");
+  }
+  const nextEntries = entries.map(copyLearning);
+  const index = nextEntries.findIndex((entry) => own(entry, "stable_ref", "stableRef") === targetRef);
+  const replacement = { stable_ref: targetRef, version_id: versionId };
+  if (index === -1) nextEntries.push(replacement);
+  else nextEntries[index] = { ...nextEntries[index], ...replacement };
+  nextEntries.sort((a, b) => {
+    const left = String(own(a, "stable_ref", "stableRef"));
+    const right = String(own(b, "stable_ref", "stableRef"));
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+  return deepFreeze({ ...copyLearning(source), entries: nextEntries });
+}

--- a/scripts/agent-native/learning.mjs
+++ b/scripts/agent-native/learning.mjs
@@ -1,0 +1,247 @@
+import { deepFreeze } from "./canonical-json.mjs";
+import { parseStableRef } from "./identity.mjs";
+import {
+  LearningError, assertEvidenceRecords, assertLearningRecord, assertLink, assertValidationRecord,
+  compactLearning, copyLearning, failLearning, learningObject, makeEvidenceRecords,
+  makeLearningRecord, makeValidationRecord, nextLearningRegistry, own, stableLearningRef,
+  textLearning,
+} from "./learning-records.mjs";
+
+const ACCEPTED = new Set(["ACCEPT", "ACCEPTED", "APPROVE", "APPROVED"]);
+const DECISIONS = new Set([...ACCEPTED, "REJECT", "REJECTED", "DENY", "DENIED", "DEFER", "DEFERRED"]);
+
+export { LearningError };
+
+function slug(ref) {
+  return ref.slice(ref.indexOf("/") + 1);
+}
+
+function requireRefKind(ref, kind, path) {
+  if (parseStableRef(ref).kind !== kind) {
+    failLearning("learning_record_kind_invalid", `${path} must use sg:${kind}/...`, path);
+  }
+  return ref;
+}
+
+function actorOf(value, path) {
+  return textLearning(
+    own(value, "verifier", "verifier_actor", "verifierActor", "verified_by", "verifiedBy", "actor", "subject"),
+    path,
+  ).trim();
+}
+
+function blocked(code, message, fields = {}) {
+  return deepFreeze({ ...fields, code, message, ok: false, status: "BLOCKED" });
+}
+
+function decisionOf(value) {
+  const decision = typeof value === "string" ? value : own(value, "decision", "status", "disposition");
+  return typeof decision === "string" ? decision.toUpperCase() : undefined;
+}
+
+function assertProposal(value) {
+  const proposal = assertLearningRecord(value, "learning_proposal", "proposal");
+  requireRefKind(proposal.stable_ref, "proposal", "proposal.stable_ref");
+  const proposer = textLearning(proposal.proposer, "proposal.proposer");
+  if (proposer !== proposer.trim()) {
+    failLearning("learning_actor_invalid", "proposal.proposer must be canonical", "proposal.proposer");
+  }
+  learningObject(proposal.claim, "proposal.claim");
+  if (!Array.isArray(proposal.changes) || proposal.changes.length === 0) {
+    failLearning("learning_changes_required", "proposal requires at least one proposed change", "proposal.changes");
+  }
+  assertEvidenceRecords(proposal.evidence, undefined, "proposal.evidence");
+  assertValidationRecord(proposal.validation, undefined, "proposal.validation");
+  return proposal;
+}
+
+function proposalOf(input) {
+  const proposal = assertProposal(own(input, "proposal"));
+  return { proposal, proposalRef: proposal.stable_ref };
+}
+
+function assertVerification(value, proposal) {
+  const verification = assertLearningRecord(value, "learning_verification", "verification");
+  requireRefKind(verification.stable_ref, "validation", "verification.stable_ref");
+  assertLink(verification, "proposal_ref", proposal.stable_ref, "verification");
+  assertLink(verification, "proposal_version_id", proposal.version_id, "verification");
+  const verifier = actorOf(verification, "verification.verifier");
+  if (verifier === proposal.proposer || verification.independent !== true || verification.verified !== true) {
+    failLearning("learning_verification_requires_independence", "verification must be independent from the proposer", "verification.verifier");
+  }
+  assertLink(verification, "independent_of", proposal.proposer, "verification");
+  const bindings = { proposal_ref: proposal.stable_ref, proposal_version_id: proposal.version_id };
+  assertEvidenceRecords(verification.evidence, bindings, "verification.evidence");
+  const validation = assertValidationRecord(verification.validation, bindings, "verification.validation");
+  if (validation.validator === proposal.proposer) {
+    failLearning("learning_verification_requires_independence", "proposal author cannot validate its verification", "verification.validation.validator");
+  }
+  return verification;
+}
+
+function assertDecision(value, proposal, verification) {
+  const governance = assertLearningRecord(value, "governance_decision", "governance_decision");
+  requireRefKind(governance.stable_ref, "governance", "governance_decision.stable_ref");
+  assertLink(governance, "proposal_ref", proposal.stable_ref, "governance_decision");
+  assertLink(governance, "proposal_version_id", proposal.version_id, "governance_decision");
+  assertLink(governance, "verification_ref", verification.stable_ref, "governance_decision");
+  assertLink(governance, "verification_version_id", verification.version_id, "governance_decision");
+  const actor = actorOf(governance, "governance_decision.actor");
+  if (actor === proposal.proposer || actor === verification.verifier) {
+    failLearning("learning_governance_requires_independence", "proposal author or verifier cannot govern the same proposal", "governance_decision.actor");
+  }
+  if (!DECISIONS.has(decisionOf(governance))) {
+    failLearning("learning_decision_invalid", "governance decision has an unsupported disposition", "governance_decision.decision");
+  }
+  return governance;
+}
+
+export function createProposal(input) {
+  const source = learningObject(input, "createProposal");
+  const ref = requireRefKind(stableLearningRef(
+    own(source, "stable_ref", "stableRef", "proposal_id", "proposalId"),
+    "createProposal.stable_ref",
+  ), "proposal", "createProposal.stable_ref");
+  const claim = learningObject(own(source, "claim"), "createProposal.claim");
+  const changes = own(source, "changes", "patch", "delta");
+  if (!Array.isArray(changes) || changes.length === 0) {
+    failLearning("learning_changes_required", "proposal requires at least one proposed change", "changes");
+  }
+  const proposer = textLearning(own(source, "proposer", "proposed_by", "proposedBy"), "proposer").trim();
+  const evidence = makeEvidenceRecords(own(source, "evidence", "evidence_links", "evidenceLinks"), {
+    path: "evidence",
+    slug: `${slug(ref)}-proposal-evidence`,
+  });
+  const validation = makeValidationRecord(own(source, "validation"), {
+    path: "validation",
+    stableRef: `sg:validation/${slug(ref)}-proposal`,
+  });
+  return makeLearningRecord(source, ref, "learning_proposal", {
+    changes: copyLearning(changes),
+    claim: copyLearning(claim),
+    evidence,
+    proposal_id: ref,
+    proposer,
+    source_task: copyLearning(own(source, "source_task", "sourceTask", "task_id", "taskId")),
+    status: "PROPOSED",
+    validation,
+  });
+}
+
+export function verifyProposal(input) {
+  const source = learningObject(input, "verifyProposal");
+  const { proposal, proposalRef } = proposalOf(source);
+  const verifier = actorOf(source, "verifier");
+  const independentOf = own(source, "independent_of", "independentOf");
+  if (verifier === proposal.proposer || (independentOf !== undefined && independentOf !== proposal.proposer)) {
+    return blocked("learning_verification_requires_independence", "verifier must be independent from proposer", {
+      independent: false, verified: false, verifier,
+    });
+  }
+  const bindings = { proposal_ref: proposalRef, proposal_version_id: proposal.version_id };
+  const evidence = makeEvidenceRecords(own(source, "evidence", "evidence_links", "evidenceLinks"), {
+    bindings,
+    path: "evidence",
+    slug: `${slug(proposalRef)}-verification-evidence`,
+  });
+  const validation = makeValidationRecord(own(source, "validation"), {
+    bindings,
+    path: "validation",
+    stableRef: `sg:validation/${slug(proposalRef)}-verification-report`,
+  });
+  if (validation.validator === proposal.proposer) {
+    return blocked("learning_verification_requires_independence", "proposal author cannot validate its verification", {
+      independent: false, verified: false, verifier,
+    });
+  }
+  const ref = `sg:validation/${slug(proposalRef)}-verification`;
+  return makeLearningRecord(source, ref, "learning_verification", {
+    evidence,
+    independent: true,
+    independent_of: proposal.proposer,
+    proposal_ref: proposalRef,
+    proposal_version_id: proposal.version_id,
+    status: "VERIFIED",
+    validation,
+    verified: true,
+    verifier,
+    verifier_actor: verifier,
+  });
+}
+
+export function decideProposal(input) {
+  const source = learningObject(input, "decideProposal");
+  const { proposal, proposalRef } = proposalOf(source);
+  const verification = assertVerification(own(source, "verification"), proposal);
+  const provided = learningObject(
+    own(source, "governance_decision", "governanceDecision") ?? source,
+    "governanceDecision",
+  );
+  const decision = textLearning(own(source, "decision") ?? decisionOf(provided), "decision").toUpperCase();
+  if (!DECISIONS.has(decision)) failLearning("learning_decision_invalid", "decision is unsupported", "decision");
+  const actor = actorOf(provided, "governanceDecision.actor");
+  if (actor === proposal.proposer || actor === verification.verifier) {
+    return blocked("learning_governance_requires_independence", "proposal author or verifier cannot govern the same proposal", { actor });
+  }
+  const ref = `sg:governance/${slug(proposalRef)}-decision`;
+  return makeLearningRecord(source, ref, "governance_decision", {
+    actor,
+    decided_at: copyLearning(own(provided, "decided_at", "decidedAt")),
+    decision,
+    proposal_ref: proposalRef,
+    proposal_version_id: proposal.version_id,
+    status: decision,
+    verification_ref: verification.stable_ref,
+    verification_version_id: verification.version_id,
+  });
+}
+
+export function promoteProposal(input) {
+  const source = learningObject(input, "promoteProposal");
+  const { proposal, proposalRef } = proposalOf(source);
+  const rawVerification = own(source, "verification") ?? own(proposal, "verification");
+  if (!rawVerification) return blocked("learning_promotion_requires_verification", "promotion requires verification", { promoted: false, proposal_ref: proposalRef });
+  const verification = assertVerification(rawVerification, proposal);
+  const rawGovernance = own(source, "governance_decision", "governanceDecision")
+    ?? (typeof own(source, "decision") === "object" ? own(source, "decision") : undefined);
+  if (!rawGovernance) return blocked("learning_promotion_requires_governance", "promotion requires governance", { promoted: false, proposal_ref: proposalRef });
+  const governance = assertDecision(rawGovernance, proposal, verification);
+  if (!ACCEPTED.has(decisionOf(governance))) {
+    return blocked("learning_promotion_requires_governance", "promotion requires an accepted decision", { promoted: false, proposal_ref: proposalRef });
+  }
+  const targetRef = stableLearningRef(
+    own(source, "target_stable_ref", "targetStableRef", "target_ref", "targetRef")
+      ?? own(proposal, "target_stable_ref", "targetStableRef")
+      ?? own(proposal.claim, "stable_ref", "stableRef"),
+    "target_stable_ref",
+  );
+  const version = makeLearningRecord({}, targetRef, "governed_version", {
+    changes: copyLearning(proposal.changes),
+    claim: copyLearning(proposal.claim),
+    evidence: copyLearning(verification.evidence),
+    governance_decision_version_id: governance.version_id,
+    proposal_ref: proposalRef,
+    proposal_version_id: proposal.version_id,
+    verification_version_id: verification.version_id,
+  });
+  const receipt = makeLearningRecord({}, `sg:governance/${slug(proposalRef)}-promotion`, "promotion_receipt", {
+    governed_version_id: version.version_id,
+    governance_decision_version_id: governance.version_id,
+    outcome: "PROMOTED",
+    proposal_ref: proposalRef,
+    proposal_version_id: proposal.version_id,
+    verification_version_id: verification.version_id,
+  });
+  return deepFreeze(compactLearning({
+    promoted: true,
+    proposal_ref: proposalRef,
+    receipt,
+    registry: nextLearningRegistry(own(source, "registry"), targetRef, version.version_id),
+    status: "PROMOTED",
+    version,
+    version_id: version.version_id,
+  }));
+}
+
+export const createLearningProposal = createProposal, verifyLearningProposal = verifyProposal;
+export const decideLearningProposal = decideProposal, promoteLearningProposal = promoteProposal;

--- a/scripts/agent-native/mcp-adapter.mjs
+++ b/scripts/agent-native/mcp-adapter.mjs
@@ -1,0 +1,173 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { canonicalize } from "./canonical-json.mjs";
+import { parseStableRef } from "./identity.mjs";
+import { agentNativeRegistry } from "./registry.mjs";
+
+function operationInputSchema(operation) {
+  const schema = structuredClone(operation.input_schema ?? { type: "object" });
+  if (Object.hasOwn(schema.properties ?? {}, "reference")) {
+    schema.properties.stable_ref = structuredClone(schema.properties.reference);
+    schema.required = (schema.required ?? []).filter((name) => name !== "reference");
+    schema.anyOf = [{ required: ["reference"] }, { required: ["stable_ref"] }];
+  }
+  return schema;
+}
+
+function normalizeInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return {};
+  if (!Object.hasOwn(input, "stable_ref")) return input;
+  const normalized = { ...input };
+  if (!Object.hasOwn(normalized, "reference")) normalized.reference = normalized.stable_ref;
+  delete normalized.stable_ref;
+  return normalized;
+}
+
+function toolResponse(envelope) {
+  return {
+    content: [{ type: "text", text: canonicalize(envelope) }],
+    isError: envelope.ok !== true,
+    structuredContent: envelope,
+  };
+}
+
+function deniedTool(operation) {
+  return toolResponse({
+    failures: [{
+      code: "operation_not_exposed",
+      message: `operation ${operation} is not exposed by the read-only MCP surface`,
+      path: "operation",
+    }],
+    ok: false,
+    operation,
+  });
+}
+
+function toolDefinition(operation) {
+  return {
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
+    description: operation.description,
+    inputSchema: operationInputSchema(operation),
+    name: operation.name,
+  };
+}
+
+function resourceContents(uri, value) {
+  return {
+    contents: [{
+      mimeType: "application/json",
+      text: canonicalize(value),
+      uri,
+    }],
+  };
+}
+
+function assertRegistry(registry) {
+  if (!registry || typeof registry.invoke !== "function" || !Array.isArray(registry.operations)) {
+    throw new TypeError("MCP registry must expose invoke and operations");
+  }
+  if (!registry.fixture?.manifest || !registry.selfDescription) {
+    throw new TypeError("MCP registry must expose an immutable manifest and self-description");
+  }
+  for (const operation of registry.operations) {
+    if (typeof operation.read_only !== "boolean") throw new TypeError(`${operation.name} must declare read_only`);
+    if (operation.read_only && operation.effect_class !== "NONE") {
+      throw new TypeError(`${operation.name} cannot expose ${operation.effect_class} effects as read-only`);
+    }
+  }
+}
+
+function objectUri(stableRef) {
+  return `sg://object/${encodeURIComponent(stableRef)}`;
+}
+
+function objectReference(encoded) {
+  if (typeof encoded !== "string" || encoded.length === 0) {
+    throw new McpError(ErrorCode.InvalidParams, "object reference must be an encoded StableRef");
+  }
+  let decoded;
+  try { decoded = decodeURIComponent(encoded); } catch {
+    throw new McpError(ErrorCode.InvalidParams, "object reference contains invalid percent encoding");
+  }
+  try { return parseStableRef(decoded).stable_ref; } catch {
+    throw new McpError(ErrorCode.InvalidParams, "object reference must decode to one governed StableRef");
+  }
+}
+
+function resolveObject(registry, encoded) {
+  const resolved = registry.invoke("resolve", { reference: objectReference(encoded) });
+  if (resolved.ok) return resolved.result;
+  const failure = resolved.failures?.[0] ?? { code: "object_not_found", message: "object could not be resolved" };
+  throw new McpError(ErrorCode.InvalidParams, `${failure.code}: ${failure.message}`);
+}
+
+export function createStyleGalleryMcpServer({ registry = agentNativeRegistry } = {}) {
+  assertRegistry(registry);
+  const server = new McpServer({ name: "StyleGallery", version: "1.0.0" });
+  const operations = registry.operations
+    .filter((operation) => operation.read_only)
+    .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  const operationByName = new Map(operations.map((operation) => [operation.name, operation]));
+
+  server.registerResource(
+    "stylegallery-self-description",
+    "sg://self",
+    {
+      description: "Immutable StyleGallery self-description and conformance profile.",
+      mimeType: "application/json",
+    },
+    async () => resourceContents("sg://self", registry.selfDescription),
+  );
+  server.registerResource(
+    "stylegallery-manifest",
+    "sg://manifest",
+    {
+      description: "Immutable manifest for the agent-native StyleGallery fixture.",
+      mimeType: "application/json",
+    },
+    async () => resourceContents("sg://manifest", registry.fixture.manifest),
+  );
+  server.registerResource(
+    "stylegallery-object",
+    new ResourceTemplate("sg://object/{reference}", {
+      list: async () => ({
+        resources: registry.fixture.records.map((record) => ({
+          description: `Immutable ${record.record_kind} record resolved from the common registry.`,
+          mimeType: "application/json",
+          name: record.stable_ref,
+          uri: objectUri(record.stable_ref),
+        })),
+      }),
+    }),
+    {
+      description: "Resolve one encoded StableRef through the immutable common registry.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => resourceContents(uri.toString(), resolveObject(registry, variables.reference)),
+  );
+
+  server.server.registerCapabilities({ tools: { listChanged: false } });
+  server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: operations.map(toolDefinition),
+  }));
+  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const operation = operationByName.get(request.params.name);
+    if (!operation) return deniedTool(request.params.name);
+    const input = normalizeInput(request.params.arguments ?? {});
+    return toolResponse(registry.invoke(operation.name, input));
+  });
+  return server;
+}
+
+export const createMcpServer = createStyleGalleryMcpServer;

--- a/scripts/agent-native/queries.mjs
+++ b/scripts/agent-native/queries.mjs
@@ -1,0 +1,173 @@
+import { canonicalize, deepFreeze } from "./canonical-json.mjs";
+import { parseStableRef, parseVersionId } from "./identity.mjs";
+import { aggregateEvidence } from "./knowledge.mjs";
+import { buildContextPackage, buildViewSnapshot } from "./retrieval.mjs";
+
+export class QueryError extends TypeError {
+  constructor(code, message, recordPath = "") {
+    super(message);
+    this.name = "QueryError";
+    this.code = code;
+    if (recordPath) this.path = recordPath;
+  }
+}
+
+function fail(code, message, recordPath = "") {
+  throw new QueryError(code, message, recordPath);
+}
+
+function compare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function inputReference(input) {
+  if (typeof input === "string") return input;
+  if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+  return input.reference ?? input.ref ?? input.stable_ref ?? input.stableRef ?? input.version_id ?? input.versionId;
+}
+
+function indexFixture(fixture) {
+  if (!fixture || !Array.isArray(fixture.records)) fail("registry_fixture_invalid", "fixture.records must be an array");
+  const records = [...fixture.records].sort((left, right) => compare(left.stable_ref, right.stable_ref) || compare(left.version_id, right.version_id));
+  const byVersion = new Map(records.map((record) => [record.version_id, record]));
+  const byStableRef = new Map();
+  for (const record of records) byStableRef.set(record.stable_ref, record);
+  return { byStableRef, byVersion, records };
+}
+
+function normalizeReference(input) {
+  const reference = inputReference(input);
+  if (typeof reference !== "string" || reference.length === 0) {
+    fail("argument_value_required", "a StableRef or VersionID is required", "reference");
+  }
+  if (reference.includes("@")) {
+    try { return { reference, version: true, stableRef: parseVersionId(reference).stable_ref }; } catch {
+      fail("version_id_malformed", "reference must be StableRef@sha256:<64 lowercase hex>", "reference");
+    }
+  }
+  try { return { reference, version: false, stableRef: parseStableRef(reference).stable_ref }; } catch {
+    fail("stable_ref_malformed", "reference must match sg:<kind>/<kebab-id>", "reference");
+  }
+}
+
+export function resolveRecord(fixture, input) {
+  const normalized = normalizeReference(input);
+  const index = indexFixture(fixture);
+  const record = normalized.version ? index.byVersion.get(normalized.reference) : index.byStableRef.get(normalized.stableRef);
+  if (!record) {
+    const code = normalized.version ? "version_id_unknown" : "stable_ref_unknown";
+    fail(code, `no immutable fixture record exists for ${normalized.reference}`, "reference");
+  }
+  return record;
+}
+
+function linked(records, kind, claimRef) {
+  return records.filter((record) => record.record_kind === kind && record.claim_ref === claimRef);
+}
+
+function claimsFor(index, subject) {
+  if (subject.record_kind === "claim") return [subject];
+  const declared = new Set(Array.isArray(subject.claim_refs) ? subject.claim_refs : []);
+  return index.records.filter((record) => record.record_kind === "claim"
+    && (record.subject_ref === subject.stable_ref || declared.has(record.stable_ref)));
+}
+
+export function queryClaims(fixture, input) {
+  const subject = resolveRecord(fixture, input);
+  const index = indexFixture(fixture);
+  const claims = claimsFor(index, subject).map((claim) => {
+    const evidence = linked(index.records, "evidence_link", claim.stable_ref);
+    const validations = linked(index.records, "validation_report", claim.stable_ref);
+    const governance = linked(index.records, "governance_decision", claim.stable_ref);
+    const policy = linked(index.records, "policy_disposition", claim.stable_ref);
+    return {
+      aggregate: aggregateEvidence({ claim, evidence_links: evidence }),
+      claim,
+      evidence,
+      governance,
+      policy_dispositions: policy,
+      validations,
+    };
+  });
+  return deepFreeze({ claims, subject_ref: subject.stable_ref, subject_version_id: subject.version_id });
+}
+
+function contextMembers(fixture, subject) {
+  const graph = queryClaims(fixture, subject.stable_ref);
+  const related = graph.claims.flatMap((entry) => [
+    entry.claim,
+    ...entry.evidence,
+    ...entry.validations,
+    ...entry.governance,
+    ...entry.policy_dispositions,
+  ]);
+  const unique = new Map([subject, ...related].map((record) => [record.version_id, record]));
+  return [...unique.values()];
+}
+
+function refSlug(stableRef) {
+  return stableRef.replace(/^sg:/, "").replace("/", "-");
+}
+
+export function queryContext(fixture, input) {
+  const subject = resolveRecord(fixture, input);
+  const members = contextMembers(fixture, subject);
+  const slug = refSlug(subject.stable_ref);
+  const snapshot = buildViewSnapshot({
+    heads: [fixture.manifest.version_id],
+    max_members: 64,
+    members,
+    policy: "sg:policy/editorial-profile-read",
+    snapshot_ref: `sg:view/${slug}-snapshot`,
+    view_spec: { stable_ref: `sg:view/${slug}-snapshot`, subject_ref: subject.stable_ref },
+  });
+  return buildContextPackage({
+    budget: { tokens: 32768 },
+    context_ref: `sg:view/${slug}-context`,
+    members,
+    policy: "sg:policy/editorial-profile-read",
+    query: subject.stable_ref,
+    query_class: "stable_ref",
+    retriever: "fixture-registry@1",
+    snapshot,
+  });
+}
+
+export function queryOperations(operationSpecs) {
+  if (!Array.isArray(operationSpecs)) fail("registry_operations_invalid", "operation specs must be an array");
+  const operations = [...operationSpecs].sort((left, right) => compare(left.name, right.name));
+  return deepFreeze({ operations });
+}
+
+export function queryDiscover(description) {
+  if (!description || typeof description !== "object" || Array.isArray(description)) {
+    fail("self_description_invalid", "discover requires a self-description object");
+  }
+  return description;
+}
+
+export function queryRetrieve(fixture, input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) fail("retrieve_input_invalid", "retrieve input must be an object");
+  const query = input.query ?? "";
+  if (typeof query !== "string") fail("retrieve_query_invalid", "retrieve query must be a string", "query");
+  const limit = input.limit ?? 32;
+  if (!Number.isInteger(limit) || limit < 0 || limit > 256) fail("retrieve_limit_invalid", "retrieve limit must be an integer from 0 to 256", "limit");
+  const needle = query.toLowerCase();
+  const members = indexFixture(fixture).records
+    .filter((record) => needle.length === 0 || canonicalize(record).toLowerCase().includes(needle))
+    .slice(0, limit);
+  return buildViewSnapshot({
+    heads: [fixture.manifest.version_id],
+    max_members: limit,
+    members,
+    snapshot_ref: "sg:view/registry-retrieval",
+    view_spec: { query, stable_ref: "sg:view/registry-retrieval" },
+  });
+}
+
+export const resolve = resolveRecord;
+export const claims = queryClaims;
+export const context = queryContext;
+export const ops = queryOperations;
+export const discover = queryDiscover;
+export const retrieve = queryRetrieve;

--- a/scripts/agent-native/registry.mjs
+++ b/scripts/agent-native/registry.mjs
@@ -1,0 +1,154 @@
+import { deepFreeze } from "./canonical-json.mjs";
+import {
+  createTask,
+  reconcileEffect,
+  recordEffectAttempt,
+  startRun,
+} from "./execution.mjs";
+import { agentNativeFixture } from "./fixture.mjs";
+import {
+  createProposal,
+  decideProposal,
+  promoteProposal,
+  verifyProposal,
+} from "./learning.mjs";
+import {
+  queryClaims,
+  queryContext,
+  queryDiscover,
+  queryOperations,
+  queryRetrieve,
+  resolveRecord,
+} from "./queries.mjs";
+import { createSelfDescription } from "./self-description.mjs";
+
+export class RegistryError extends TypeError {
+  constructor(code, message, recordPath = "") {
+    super(message);
+    this.name = "RegistryError";
+    this.code = code;
+    if (recordPath) this.path = recordPath;
+  }
+}
+
+function failure(code, message, recordPath = "") {
+  return recordPath ? { code, message, path: recordPath } : { code, message };
+}
+
+function compareFailures(left, right) {
+  const leftKey = `${left.code}\u0000${left.path ?? ""}\u0000${left.message}`;
+  const rightKey = `${right.code}\u0000${right.path ?? ""}\u0000${right.message}`;
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+}
+
+function failed(operation, failures) {
+  return deepFreeze({ failures: [...failures].sort(compareFailures), ok: false, operation });
+}
+
+function succeeded(operation, result) {
+  return deepFreeze({ ok: true, operation, result });
+}
+
+function validateValue(schema, value, recordPath) {
+  if (schema.type === "string" && typeof value !== "string") return failure("operation_input_invalid", `${recordPath} must be a string`, recordPath);
+  if (schema.type === "integer" && !Number.isInteger(value)) return failure("operation_input_invalid", `${recordPath} must be an integer`, recordPath);
+  if (typeof schema.minimum === "number" && value < schema.minimum) return failure("operation_input_invalid", `${recordPath} must be at least ${schema.minimum}`, recordPath);
+  return undefined;
+}
+
+function validateInput(spec, input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return [failure("operation_input_invalid", "operation input must be an object")];
+  }
+  const schema = spec.input_schema ?? { type: "object" };
+  const properties = schema.properties ?? {};
+  const failures = [];
+  for (const key of schema.required ?? []) {
+    if (!Object.hasOwn(input, key)) failures.push(failure("operation_input_required", `${key} is required`, key));
+  }
+  if (schema.additionalProperties === false) {
+    for (const key of Object.keys(input)) if (!Object.hasOwn(properties, key)) {
+      failures.push(failure("operation_input_unknown", `${key} is not accepted by ${spec.name}`, key));
+    }
+  }
+  for (const [key, value] of Object.entries(input)) {
+    if (!Object.hasOwn(properties, key)) continue;
+    const issue = validateValue(properties[key], value, key);
+    if (issue) failures.push(issue);
+  }
+  return failures;
+}
+
+function handlers(fixture, operations, selfDescription) {
+  return new Map([
+    ["claims", (input) => queryClaims(fixture, input)],
+    ["context", (input) => queryContext(fixture, input)],
+    ["discover", () => queryDiscover(selfDescription)],
+    ["effect.record", (input) => recordEffectAttempt(input)],
+    ["effect.reconcile", (input) => reconcileEffect(input)],
+    ["ops", () => queryOperations(operations)],
+    ["proposal.create", (input) => createProposal(input)],
+    ["proposal.decide", (input) => decideProposal(input)],
+    ["proposal.promote", (input) => promoteProposal(input)],
+    ["proposal.verify", (input) => verifyProposal(input)],
+    ["resolve", (input) => resolveRecord(fixture, input)],
+    ["retrieve", (input) => queryRetrieve(fixture, input)],
+    ["run.start", (input) => startRun(input)],
+    ["task.create", (input) => createTask(input)],
+  ]);
+}
+
+function assertOperationMetadata(operations, operationHandlers) {
+  for (const operation of operations) {
+    if (typeof operation.read_only !== "boolean") {
+      throw new RegistryError("operation_read_only_required", `${operation.name} must declare read_only`);
+    }
+    if (operation.read_only && operation.effect_class !== "NONE") {
+      throw new RegistryError("operation_read_only_effect_invalid", `${operation.name} cannot be read-only with ${operation.effect_class} effects`);
+    }
+    if (!operationHandlers.has(operation.name)) {
+      throw new RegistryError("operation_handler_missing", `${operation.name} has no common-registry handler`);
+    }
+  }
+}
+
+export function createOperationRegistry({ fixture = agentNativeFixture } = {}) {
+  const operations = fixture.records
+    .filter((record) => record.record_kind === "operation")
+    .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  if (new Set(operations.map((operation) => operation.name)).size !== operations.length) {
+    throw new RegistryError("operation_name_duplicate", "operation names must be unique");
+  }
+  const selfDescription = createSelfDescription({ fixture, operations });
+  const operationByName = new Map(operations.map((operation) => [operation.name, operation]));
+  const operationHandlers = handlers(fixture, operations, selfDescription);
+  assertOperationMetadata(operations, operationHandlers);
+  const invoke = (operation, input = {}) => {
+    if (typeof operation !== "string" || operation.length === 0) {
+      return failed(null, [failure("operation_required", "operation name is required")]);
+    }
+    const spec = operationByName.get(operation);
+    if (!spec || !operationHandlers.has(operation)) {
+      return failed(operation, [failure("operation_unknown", `unknown operation ${operation}`, "operation")]);
+    }
+    const inputFailures = validateInput(spec, input);
+    if (inputFailures.length > 0) return failed(operation, inputFailures);
+    try { return succeeded(operation, operationHandlers.get(operation)(input)); } catch (error) {
+      return failed(operation, [failure(error?.code ?? "operation_failed", error instanceof Error ? error.message : String(error), error?.path)]);
+    }
+  };
+  return Object.freeze({ fixture, invoke, operations: deepFreeze([...operations]), selfDescription });
+}
+
+export const agentNativeRegistry = createOperationRegistry();
+export const readOnlyOperationNames = deepFreeze(agentNativeRegistry.operations
+  .filter((operation) => operation.read_only)
+  .map((operation) => operation.name));
+
+export function invokeOperation(operation, input = {}, registry = agentNativeRegistry) {
+  if (!registry || typeof registry.invoke !== "function") throw new RegistryError("registry_invalid", "registry must expose invoke");
+  return registry.invoke(operation, input);
+}
+
+export const invokeRegistryOperation = invokeOperation;
+export const operationRegistry = agentNativeRegistry;

--- a/scripts/agent-native/retrieval.mjs
+++ b/scripts/agent-native/retrieval.mjs
@@ -1,0 +1,171 @@
+import { cloneAndFreeze, canonicalize, hashCanonical } from "./canonical-json.mjs";
+import { createStableRef } from "./identity.mjs";
+
+function pick(value, ...keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key)) return value[key];
+  return undefined;
+}
+
+function objectInput(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${name} expects an object`);
+  return value;
+}
+
+function copy(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+function canonicalFreeze(value) {
+  return cloneAndFreeze(JSON.parse(canonicalize(value)));
+}
+
+function refOf(value) {
+  return pick(value, "stable_ref", "stableRef", "ref", "id") ?? "";
+}
+
+function versionOf(value) {
+  return pick(value, "version_id", "versionId", "version") ?? "";
+}
+
+function memberReference(member) {
+  const reference = {};
+  const stableRef = refOf(member);
+  const versionId = versionOf(member);
+  const contentHash = pick(member, "content_sha256", "contentHash", "sha256");
+  if (stableRef) reference.stable_ref = stableRef;
+  if (versionId) reference.version_id = versionId;
+  if (contentHash) reference.content_sha256 = contentHash;
+  return reference;
+}
+
+function sortedUniqueStrings(value) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) throw new TypeError("heads must be an array");
+  return [...new Set(value.map((item) => {
+    if (typeof item !== "string" || item.length === 0) throw new TypeError("head IDs must be non-empty strings");
+    return item;
+  }))].sort();
+}
+
+function normalizeMembers(value, maxMembers = 256) {
+  const source = value ?? [];
+  if (!Array.isArray(source)) throw new TypeError("members must be an array");
+  if (!Number.isInteger(maxMembers) || maxMembers < 0) throw new TypeError("maxMembers must be a non-negative integer");
+  const members = source.map((member) => {
+    if (!member || typeof member !== "object" || Array.isArray(member)) throw new TypeError("members must contain objects");
+    return copy(member);
+  });
+  members.sort((left, right) => {
+    const leftRef = String(refOf(left));
+    const rightRef = String(refOf(right));
+    const byRef = leftRef < rightRef ? -1 : leftRef > rightRef ? 1 : 0;
+    if (byRef) return byRef;
+    const leftVersion = String(versionOf(left));
+    const rightVersion = String(versionOf(right));
+    const byVersion = leftVersion < rightVersion ? -1 : leftVersion > rightVersion ? 1 : 0;
+    if (byVersion) return byVersion;
+    const leftCanonical = canonicalize(left);
+    const rightCanonical = canonicalize(right);
+    return leftCanonical < rightCanonical ? -1 : leftCanonical > rightCanonical ? 1 : 0;
+  });
+  return { members: members.slice(0, maxMembers), truncated: members.length > maxMembers };
+}
+
+function snapshotIdentity(payload, stableRef, recordKind) {
+  const versionPayload = {
+    schema_version: "1.0",
+    record_kind: recordKind,
+    stable_ref: stableRef,
+    ...payload,
+  };
+  const digest = hashCanonical(versionPayload);
+  return {
+    version_id: `${stableRef}@${digest}`,
+    sha256: digest,
+    cache_key: `${stableRef}@${digest}`,
+  };
+}
+
+/** Build a bounded, immutable, source-preserving retrieval view. */
+export function buildViewSnapshot(input) {
+  const source = objectInput(input, "buildViewSnapshot");
+  const rawView = pick(source, "view_spec", "viewSpec") ?? {};
+  const viewSpec = copy(rawView);
+  const stableRef = pick(source, "snapshot_ref", "snapshotRef")
+    ?? pick(viewSpec, "stable_ref", "stableRef")
+    ?? "sg:view/snapshot";
+  const canonicalStableRef = createStableRef(stableRef);
+  const requestedLimit = pick(source, "max_members", "maxMembers", "limit");
+  const maxMembers = requestedLimit === undefined ? 256 : Number(requestedLimit);
+  if (!Number.isInteger(maxMembers) || maxMembers < 0) throw new TypeError("maxMembers must be a non-negative integer");
+  const normalized = normalizeMembers(pick(source, "members", "entries", "items"), maxMembers);
+  const payload = {
+    as_of: pick(source, "as_of", "asOf"),
+    builder_version: pick(source, "builder_version", "builderVersion") ?? "retriever@1",
+    heads: sortedUniqueStrings(pick(source, "heads", "event_heads", "eventHeads")),
+    members: normalized.members,
+    policy: copy(pick(source, "policy", "policy_ref", "policyRef")),
+    snapshot_ref: canonicalStableRef,
+    truncated: normalized.truncated,
+    transaction_at: pick(source, "transaction_at", "transactionAt", "transaction_watermark", "transactionWatermark"),
+    valid_at: pick(source, "valid_at", "validAt", "valid_watermark", "validWatermark"),
+    view_spec: viewSpec,
+  };
+  for (const [key, value] of Object.entries(payload)) if (value === undefined) delete payload[key];
+  const supplied = pick(source, "version_id", "versionId");
+  const identity = snapshotIdentity(payload, canonicalStableRef, "view_snapshot");
+  if (supplied !== undefined && supplied !== identity.version_id) throw new TypeError("snapshot version_id does not match content");
+  return canonicalFreeze({ schema_version: "1.0", record_kind: "view_snapshot", stable_ref: canonicalStableRef, ...payload, ...identity });
+}
+
+export const createViewSnapshot = buildViewSnapshot;
+
+function estimateTokens(member) {
+  const text = pick(member, "content", "text", "summary") ?? canonicalize(member);
+  return Math.max(1, Math.ceil(String(text).length / 4));
+}
+
+/** Build a deterministic, budget-bounded context package linked to a snapshot. */
+export function buildContextPackage(input) {
+  const source = objectInput(input, "buildContextPackage");
+  const snapshot = pick(source, "snapshot");
+  const view = snapshot && typeof snapshot === "object"
+    ? snapshot
+    : buildViewSnapshot({ ...source, viewSpec: { stableRef: "sg:view/context" } });
+  const suppliedMembers = pick(source, "members", "entries", "items") ?? pick(view, "members", "entries", "items") ?? [];
+  const normalized = normalizeMembers(suppliedMembers, Number(pick(source, "max_members", "maxMembers") ?? 256));
+  const budgetInput = pick(source, "budget") ?? {};
+  const tokenBudget = Number(typeof budgetInput === "number" ? budgetInput : pick(budgetInput, "tokens", "token_budget", "tokenBudget") ?? 0);
+  if (!Number.isInteger(tokenBudget) || tokenBudget < 0) throw new TypeError("budget.tokens must be a non-negative integer");
+  let usedTokens = 0;
+  const members = [];
+  for (const member of normalized.members) {
+    const cost = estimateTokens(member);
+    if (usedTokens + cost > tokenBudget) break;
+    members.push(member);
+    usedTokens += cost;
+  }
+  const payload = {
+    budget: { tokens: tokenBudget, used_tokens: usedTokens, truncated: members.length < normalized.members.length },
+    members,
+    member_refs: members.map(memberReference).filter((member) => Object.keys(member).length > 0),
+    member_manifest: members.map(memberReference).filter((member) => Object.keys(member).length > 0),
+    policy: copy(pick(source, "policy", "policy_ref", "policyRef") ?? pick(view, "policy", "policy_ref", "policyRef")),
+    query: pick(source, "query"),
+    query_class: pick(source, "query_class", "queryClass"),
+    retriever: pick(source, "retriever"),
+    selectors: copy(pick(source, "selectors", "selector")),
+    snapshot: pick(view, "version_id", "versionId") ?? pick(view, "snapshot_ref", "snapshotRef", "stable_ref", "stableRef"),
+    snapshot_ref: pick(view, "snapshot_ref", "snapshotRef", "stable_ref", "stableRef"),
+    snapshot_version_id: pick(view, "version_id", "versionId"),
+    assembly_receipt: copy(pick(source, "assembly_receipt", "assemblyReceipt")),
+  };
+  for (const [key, value] of Object.entries(payload)) if (value === undefined) delete payload[key];
+  const stableRef = pick(source, "context_ref", "contextRef") ?? "sg:view/context";
+  const canonicalStableRef = createStableRef(stableRef);
+  const identity = snapshotIdentity(payload, canonicalStableRef, "context_package");
+  return canonicalFreeze({ schema_version: "1.0", record_kind: "context_package", stable_ref: canonicalStableRef, ...payload, ...identity });
+}
+
+export const createContextPackage = buildContextPackage;

--- a/scripts/agent-native/self-description.mjs
+++ b/scripts/agent-native/self-description.mjs
@@ -1,0 +1,160 @@
+import crypto from "node:crypto";
+import { deepFreeze, hashCanonical } from "./canonical-json.mjs";
+import { createVersionId } from "./identity.mjs";
+
+export const AGENT_REF = "sg:agent/stylegallery";
+export const CONFORMANCE_PROFILE_REF = "sg:profile/agent-native-read-conformance";
+
+export class SelfDescriptionError extends TypeError {
+  constructor(code, message) {
+    super(message);
+    this.name = "SelfDescriptionError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new SelfDescriptionError(code, message);
+}
+
+function byRef(fixture, stableRef) {
+  const record = fixture.records.find((item) => item.stable_ref === stableRef);
+  if (!record) fail("self_description_record_missing", `required fixture record ${stableRef} is missing`);
+  return record;
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function receiptVersion(receipt) {
+  const payload = { ...receipt };
+  delete payload.version_id;
+  delete payload.versionId;
+  return createVersionId({ stableRef: receipt.stable_ref, payload });
+}
+
+/**
+ * Verify an execution receipt without executing its command again.  The
+ * receipt is an immutable, content-addressed observation: its fixture source
+ * VersionID, command, normalized result digest, and independent verifier are
+ * all checked before a conformance claim can be projected as verified.
+ */
+export function verifyConformanceReceipt({ fixture, receipt, source }) {
+  if (!receipt || receipt.record_kind !== "execution_receipt") {
+    fail("self_description_receipt_kind_invalid", "conformance evidence must be an execution receipt");
+  }
+  if (!source || source.record_kind !== "executable_fixture") {
+    fail("self_description_receipt_source_invalid", "execution receipt must reference an executable fixture");
+  }
+  if (receipt.fixture_ref !== fixture.fixture_ref) {
+    fail("self_description_receipt_fixture_mismatch", "execution receipt fixture_ref does not match the loaded fixture");
+  }
+  if (receipt.fixture_record_ref !== source.stable_ref || receipt.fixture_version_id !== source.version_id) {
+    fail("self_description_receipt_version_mismatch", "execution receipt is not bound to the executable fixture VersionID");
+  }
+  if (receipt.command !== source.command) {
+    fail("self_description_receipt_command_mismatch", "execution receipt command does not match the executable fixture");
+  }
+  const result = receipt.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    fail("self_description_receipt_result_invalid", "execution receipt must contain a normalized result object");
+  }
+  if (result.exit_code !== source.expected?.exit_code || result.report_ok !== source.expected?.report_ok) {
+    fail("self_description_receipt_result_mismatch", "execution receipt result does not match fixture expectations");
+  }
+  const expectedStderrHash = sha256(String(source.expected?.stderr ?? ""));
+  if (result.stderr_sha256 !== expectedStderrHash) {
+    fail("self_description_receipt_stderr_mismatch", "execution receipt stderr digest does not match fixture expectations");
+  }
+  if (typeof result.stderr_sha256 !== "string" || !/^[a-f0-9]{64}$/.test(result.stderr_sha256)) {
+    fail("self_description_receipt_digest_invalid", "execution receipt stderr digest must be lowercase sha256 hex");
+  }
+  if (receipt.result_sha256 !== hashCanonical(result)) {
+    fail("self_description_receipt_result_digest_mismatch", "execution receipt result_sha256 does not match canonical result bytes");
+  }
+  if (receipt.version_id !== receiptVersion(receipt)) {
+    fail("self_description_receipt_version_digest_mismatch", "execution receipt VersionID does not match immutable receipt bytes");
+  }
+  const verification = receipt.verification;
+  if (!verification || verification.status !== "PASS" || verification.method !== "captured-command-result") {
+    fail("self_description_receipt_unverified", "execution receipt must carry a PASS captured-command verification");
+  }
+  const verifier = fixture.records.find((record) => record.stable_ref === verification.verifier_ref);
+  if (!verifier || verifier.record_kind !== "validator" || verifier.validator_version !== verification.verifier_version) {
+    fail("self_description_receipt_verifier_invalid", "execution receipt verifier is not a fixture validator version");
+  }
+  return deepFreeze({ receipt, source, verifier });
+}
+
+function conformanceClaims(fixture, profile) {
+  const refs = Array.isArray(profile.claim_refs) ? profile.claim_refs : [];
+  return refs.map((claimRef) => {
+    const claim = byRef(fixture, claimRef);
+    const evidence = fixture.records.filter((record) => record.record_kind === "evidence_link" && record.claim_ref === claimRef);
+    const sources = evidence.map((link) => byRef(fixture, link.source_ref));
+    if (sources.length === 0 || sources.some((source) => source.record_kind !== "executable_fixture")) {
+      fail("self_description_evidence_not_executable", `conformance claim ${claimRef} must point only at executable fixture evidence`);
+    }
+    const validations = fixture.records.filter((record) => record.record_kind === "validation_report" && record.claim_ref === claimRef);
+    const execution_receipts = sources.map((source) => {
+      const receipts = fixture.records.filter((record) => record.record_kind === "execution_receipt" && record.fixture_record_ref === source.stable_ref);
+      if (receipts.length !== 1) {
+        fail("self_description_execution_receipt_missing", `conformance source ${source.stable_ref} must have exactly one immutable execution receipt`);
+      }
+      return verifyConformanceReceipt({ fixture, receipt: receipts[0], source });
+    });
+    return { claim, evidence, executable_sources: sources, execution_receipts, validations };
+  });
+}
+
+function operationSummary(operation) {
+  return {
+    adapters: operation.adapters,
+    effect_class: operation.effect_class,
+    idempotent: operation.idempotent,
+    name: operation.name,
+    read_only: operation.read_only,
+    stable_ref: operation.stable_ref,
+    version_id: operation.version_id,
+  };
+}
+
+export function createSelfDescription({ fixture, operations }) {
+  if (!fixture || !Array.isArray(fixture.records) || !fixture.manifest) {
+    fail("self_description_fixture_invalid", "self-description requires an immutable fixture");
+  }
+  if (!Array.isArray(operations)) fail("self_description_operations_invalid", "operations must be an array");
+  const agent = byRef(fixture, AGENT_REF);
+  const conformanceProfile = byRef(fixture, CONFORMANCE_PROFILE_REF);
+  if (conformanceProfile.conformance_level !== "fixture_verified") {
+    fail("self_description_profile_unverified", "conformance profile must declare fixture_verified only after receipt verification");
+  }
+  const summaries = operations.map(operationSummary).sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  return deepFreeze({
+    agent,
+    conformance: {
+      claims: conformanceClaims(fixture, conformanceProfile),
+      profile: conformanceProfile,
+      status: "fixture_verified",
+    },
+    manifest: {
+      entry_count: fixture.manifest.entries.length,
+      manifest_ref: fixture.manifest.manifest_ref,
+      sha256: fixture.manifest.sha256,
+      version_id: fixture.manifest.version_id,
+    },
+    operation_digest: hashCanonical(summaries),
+    operations: summaries,
+    protocol_surfaces: {
+      a2a: { mode: "task_projection", protocol: "A2A v1" },
+      ag_ui: { mode: "event_projection", protocol: "AG-UI 0.0.57" },
+      cli: { commands: summaries.filter((item) => item.adapters.includes("cli")).map((item) => item.name), format: "json" },
+      mcp: { mode: "read_only", operations: summaries.filter((item) => item.read_only).map((item) => item.name), protocol: "MCP v1" },
+    },
+    schema_version: "1.0",
+  });
+}
+
+export const describeAgentNative = createSelfDescription;
+export const createConformanceProfile = createSelfDescription;

--- a/scripts/sg-mcp.mjs
+++ b/scripts/sg-mcp.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { createStyleGalleryMcpServer } from "./agent-native/mcp-adapter.mjs";
+
+async function main() {
+  const server = createStyleGalleryMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+await main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/sg.mjs
+++ b/scripts/sg.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+function emergencyReport(error) {
+  return {
+    failures: [{
+      code: error?.code ?? "cli_failed",
+      message: error instanceof Error ? error.message : String(error),
+      ...(error?.path ? { path: error.path } : {}),
+    }],
+    ok: false,
+    operation: null,
+  };
+}
+
+async function main() {
+  try {
+    const { runCli } = await import("./agent-native/cli-adapter.mjs");
+    const result = runCli(process.argv.slice(2));
+    process.stdout.write(result.output);
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify(emergencyReport(error), null, 2)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/test-agent-adapter-conformance.mjs
+++ b/scripts/test-agent-adapter-conformance.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+/**
+ * Cross-surface conformance test.
+ *
+ * A CLI JSON-RPC-ish envelope and an MCP envelope are transport projections;
+ * this harness removes only those envelopes and compares the canonical domain
+ * payload (or the stable failure codes).  It therefore catches an adapter
+ * that returns a plausible wrapper while silently changing domain semantics.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = path.join(repositoryRoot, "scripts", "sg.mjs");
+const profileRef = "sg:profile/editorial-reference-profile";
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+  }
+  return value;
+}
+
+function equal(left, right) {
+  return JSON.stringify(stable(left)) === JSON.stringify(stable(right));
+}
+
+function parseJson(text) {
+  if (typeof text !== "string" || text.length === 0) return null;
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+function codes(envelope) {
+  return Array.isArray(envelope?.failures)
+    ? envelope.failures.map((failure) => failure?.code).filter((code) => typeof code === "string").sort()
+    : [];
+}
+
+function unwrap(value, operation) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (typeof value.ok === "boolean") {
+    if (value.ok === true) return { ok: true, operation: value.operation ?? operation, result: value.result ?? null };
+    return { ok: false, operation: value.operation ?? operation, failures: codes(value) };
+  }
+  if (value.result && typeof value.result === "object" && typeof value.result.ok === "boolean") {
+    return unwrap(value.result, operation);
+  }
+  return null;
+}
+
+function cliInvocation(args) {
+  const child = spawnSync(process.execPath, [cliPath, ...args, "--format", "json"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+  const parsed = parseJson(child.stdout);
+  return {
+    child,
+    envelope: unwrap(parsed, args[0]),
+    parsed,
+  };
+}
+
+function mcpEnvelope(response, operation) {
+  const structured = response?.structuredContent;
+  const text = response?.content?.find((item) => item?.type === "text")?.text;
+  const parsed = structured && typeof structured === "object" ? structured : parseJson(text);
+  return unwrap(parsed, operation);
+}
+
+function result(name, expected, actual, ok) {
+  return { actual, expected, name, ok };
+}
+
+function compare(name, cliRun, mcpRun) {
+  const cliEnvelope = cliRun.envelope;
+  const mcpEnvelopeValue = mcpRun.envelope;
+  if (!cliEnvelope || !mcpEnvelopeValue) {
+    return result(
+      name,
+      "both adapters produce a parseable {ok,operation,result|failures} envelope",
+      {
+        cli: { status: cliRun.child.status, stderr: cliRun.child.stderr, envelope: cliEnvelope, stdout: cliRun.child.stdout },
+        mcp: { response: mcpRun.response, envelope: mcpEnvelopeValue },
+      },
+      false,
+    );
+  }
+  if (cliEnvelope.ok !== mcpEnvelopeValue.ok) {
+    return result(
+      name,
+      "CLI and MCP agree on success versus failure",
+      { cli: cliEnvelope, mcp: mcpEnvelopeValue },
+      false,
+    );
+  }
+  if (cliEnvelope.ok === false) {
+    const cliCodes = cliEnvelope.failures;
+    const mcpCodes = mcpEnvelopeValue.failures;
+    return result(
+      name,
+      "CLI and MCP expose identical stable error codes",
+      { cliCodes, mcpCodes, cliStatus: cliRun.child.status, mcpResponse: mcpRun.response },
+      cliRun.child.status !== 0 && cliRun.child.stderr.length === 0 && equal(cliCodes, mcpCodes),
+    );
+  }
+  return result(
+    name,
+    "CLI and MCP expose identical operation and canonical domain result",
+    { cli: cliEnvelope, mcp: mcpEnvelopeValue },
+    cliRun.child.status === 0
+      && cliRun.child.stderr.length === 0
+      && cliEnvelope.operation === mcpEnvelopeValue.operation
+      && equal(cliEnvelope.result, mcpEnvelopeValue.result),
+  );
+}
+
+async function loadSdk(results) {
+  try {
+    const sdk = {
+      ...(await import("@modelcontextprotocol/sdk/server/mcp.js")),
+      ...(await import("@modelcontextprotocol/sdk/client/index.js")),
+      ...(await import("@modelcontextprotocol/sdk/inMemory.js")),
+    };
+    const available = typeof sdk.McpServer === "function"
+      && typeof sdk.Client === "function"
+      && typeof sdk.InMemoryTransport?.createLinkedPair === "function";
+    results.push(result(
+      "conformance_sdk_available",
+      "official stable MCP SDK is available",
+      { available },
+      available,
+    ));
+    return available ? sdk : null;
+  } catch (error) {
+    results.push(result(
+      "conformance_sdk_available",
+      "official stable MCP SDK is available",
+      { code: "mcp_sdk_unavailable", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+    return null;
+  }
+}
+
+async function loadAdapter(results) {
+  try {
+    const adapter = await import("./agent-native/mcp-adapter.mjs");
+    const factory = adapter.createStyleGalleryMcpServer ?? adapter.createMcpServer;
+    results.push(result(
+      "conformance_adapter_available",
+      "mcp-adapter exports createStyleGalleryMcpServer",
+      { exports: Object.keys(adapter).sort() },
+      typeof factory === "function",
+    ));
+    return factory;
+  } catch (error) {
+    results.push(result(
+      "conformance_adapter_available",
+      "mcp-adapter exports createStyleGalleryMcpServer",
+      { code: "mcp_adapter_unavailable", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+    return null;
+  }
+}
+
+async function main() {
+  const results = [];
+  const sdk = await loadSdk(results);
+  const createServer = await loadAdapter(results);
+  if (!sdk || !createServer) {
+    const report = { ok: false, results };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const server = await createServer();
+  const [clientTransport, serverTransport] = sdk.InMemoryTransport.createLinkedPair();
+  const client = new sdk.Client({ name: "stylegallery-adapter-conformance", version: "1.0.0" });
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const cases = [
+      { name: "discover", cli: ["discover"], mcp: { name: "discover", arguments: {} } },
+      { name: "ops", cli: ["ops"], mcp: { name: "ops", arguments: {} } },
+      { name: "resolve", cli: ["resolve", profileRef], mcp: { name: "resolve", arguments: { stable_ref: profileRef } } },
+      { name: "claims", cli: ["claims", profileRef], mcp: { name: "claims", arguments: { stable_ref: profileRef } } },
+      { name: "context", cli: ["context", profileRef], mcp: { name: "context", arguments: { stable_ref: profileRef } } },
+      { name: "resolve_malformed", cli: ["resolve", "not-a-stable-ref"], mcp: { name: "resolve", arguments: { stable_ref: "not-a-stable-ref" } } },
+    ];
+    for (const testCase of cases) {
+      const cliRun = cliInvocation(testCase.cli);
+      let response;
+      let mcpError = null;
+      try {
+        response = await client.callTool(testCase.mcp);
+      } catch (error) {
+        mcpError = error;
+      }
+      const mcpRun = {
+        envelope: mcpError ? null : mcpEnvelope(response, testCase.name.split("_")[0]),
+        response: mcpError ? { error: mcpError instanceof Error ? mcpError.message : String(mcpError) } : response,
+      };
+      if (mcpError && cliRun.envelope?.ok === false) {
+        results.push(result(
+          `adapter_equivalence_${testCase.name}`,
+          "both adapters preserve the same stable failure code",
+          { cli: cliRun.envelope, mcpError: mcpRun.response },
+          false,
+        ));
+      } else {
+        results.push(compare(`adapter_equivalence_${testCase.name}`, cliRun, mcpRun));
+      }
+    }
+  } catch (error) {
+    results.push(result(
+      "adapter_conformance_round_trip",
+      "CLI and MCP conformance fixture executes over an initialized in-memory transport",
+      { code: "conformance_round_trip_failed", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+  } finally {
+    await client.close().catch(() => {});
+    const closed = server.close?.();
+    if (closed && typeof closed.catch === "function") await closed.catch(() => {});
+  }
+
+  const report = { ok: results.every((item) => item.ok), results };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+await main().catch((error) => {
+  const report = {
+    ok: false,
+    results: [result(
+      "conformance_harness_runtime",
+      "harness emits structured JSON instead of crashing",
+      { code: "conformance_harness_runtime", error: error instanceof Error ? error.message : String(error) },
+      false,
+    )],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-agent-conformance-receipt.mjs
+++ b/scripts/test-agent-conformance-receipt.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { agentNativeFixture } from "./agent-native/fixture.mjs";
+import { createVersionId } from "./agent-native/identity.mjs";
+import { createSelfDescription } from "./agent-native/self-description.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const operations = agentNativeFixture.records.filter((record) => record.record_kind === "operation");
+
+function check(name, expected, actual, ok) {
+  return { actual, expected, name, ok };
+}
+
+function selfDescriptionFor(records) {
+  return createSelfDescription({
+    fixture: {
+      fixture_ref: agentNativeFixture.fixture_ref,
+      manifest: agentNativeFixture.manifest,
+      records,
+    },
+    operations,
+  });
+}
+
+function tamperedRecords(mutator) {
+  const records = structuredClone(agentNativeFixture.records);
+  mutator(records);
+  return records;
+}
+
+function expectedFailure(name, code, mutator) {
+  try {
+    selfDescriptionFor(tamperedRecords(mutator));
+    return check(name, code, { code: "no_failure" }, false);
+  } catch (error) {
+    return check(name, code, { code: error?.code ?? "unknown", message: error?.message }, error?.code === code);
+  }
+}
+
+function runDiscover() {
+  const child = spawnSync(process.execPath, [path.join(repositoryRoot, "scripts", "sg.mjs"), "discover", "--format", "json"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+  let report;
+  try { report = JSON.parse(child.stdout); } catch { report = null; }
+  const claims = report?.result?.conformance?.claims ?? [];
+  const receipt = claims[0]?.execution_receipts?.[0];
+  return check(
+    "discover_exposes_verified_execution_receipt",
+    "discover is successful only with fixture_verified status and a bound PASS receipt",
+    {
+      status: child.status,
+      stderr: child.stderr,
+      conformance_status: report?.result?.conformance?.status,
+      receipt_ref: receipt?.receipt?.stable_ref,
+      fixture_version_id: receipt?.receipt?.fixture_version_id,
+      verifier_status: receipt?.receipt?.verification?.status,
+    },
+    child.status === 0
+      && child.signal === null
+      && child.stderr === ""
+      && report?.ok === true
+      && report?.result?.conformance?.status === "fixture_verified"
+      && receipt?.receipt?.record_kind === "execution_receipt"
+      && receipt?.receipt?.verification?.status === "PASS"
+      && receipt?.receipt?.fixture_version_id === receipt?.source?.version_id,
+  );
+}
+
+const results = [
+  check(
+    "default_fixture_receipt_verifies",
+    "the immutable fixture has one content-bound execution receipt",
+    {
+      status: createSelfDescription({ fixture: agentNativeFixture, operations }).conformance.status,
+      receipts: agentNativeFixture.records.filter((record) => record.record_kind === "execution_receipt").length,
+    },
+    agentNativeFixture.records.filter((record) => record.record_kind === "execution_receipt").length === 1,
+  ),
+  expectedFailure("missing_receipt_cannot_claim_fixture_verified", "self_description_execution_receipt_missing", (records) => {
+    const index = records.findIndex((record) => record.record_kind === "execution_receipt");
+    records.splice(index, 1);
+  }),
+  expectedFailure("wrong_fixture_version_is_rejected", "self_description_receipt_version_mismatch", (records) => {
+    records.find((record) => record.record_kind === "execution_receipt").fixture_version_id = "sg:artifact/sg-cli-conformance-test@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+  }),
+  expectedFailure("tampered_result_digest_is_rejected", "self_description_receipt_result_digest_mismatch", (records) => {
+    records.find((record) => record.record_kind === "execution_receipt").result_sha256 = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+  }),
+  expectedFailure("unverified_receipt_is_rejected", "self_description_receipt_unverified", (records) => {
+    const receipt = records.find((record) => record.record_kind === "execution_receipt");
+    receipt.verification.status = "PASS_WITH_WARNINGS";
+    const payload = { ...receipt };
+    delete payload.version_id;
+    receipt.version_id = createVersionId({ stableRef: receipt.stable_ref, payload });
+  }),
+  runDiscover(),
+];
+
+const report = { ok: results.every((result) => result.ok), results };
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/test-agent-events.mjs
+++ b/scripts/test-agent-events.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { appendEvent, eventHeads } from "./agent-native/events.mjs";
+
+const cases = [];
+
+function test(name, scenario) {
+  try {
+    scenario();
+    cases.push({ name, ok: true });
+  } catch (error) {
+    cases.push({
+      error: error instanceof Error ? error.message : String(error),
+      name,
+      ok: false,
+    });
+  }
+}
+
+function equal(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: expected ${expected}, received ${actual}`);
+}
+
+function rejectsCycle(events, event) {
+  try {
+    appendEvent({ event, events });
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes("cycle")) return;
+    throw error;
+  }
+  throw new Error("expected appendEvent to reject a causal cycle");
+}
+
+test("append_rejects_two_node_cycle_completed_by_new_event", () => {
+  // Given A references a parent B that is not present yet.
+  const events = [{ event_id: "sg:event/a", parents: ["sg:event/b"], type: "a" }];
+  // When B is appended with A as its parent.
+  // Then combined-graph validation rejects the newly completed cycle.
+  rejectsCycle(events, { event_id: "sg:event/b", parents: ["sg:event/a"], type: "b" });
+});
+
+test("append_rejects_long_cycle_completed_by_new_event", () => {
+  // Given A -> B -> C with C unresolved.
+  const events = [
+    { event_id: "sg:event/a", parents: ["sg:event/b"], type: "a" },
+    { event_id: "sg:event/b", parents: ["sg:event/c"], type: "b" },
+  ];
+  // When C is appended pointing back to A.
+  // Then combined-graph validation rejects the three-node cycle.
+  rejectsCycle(events, { event_id: "sg:event/c", parents: ["sg:event/a"], type: "c" });
+});
+
+test("append_allows_unresolved_parent_to_close_acyclically", () => {
+  // Given a child references a future parent.
+  const events = [{ event_id: "sg:event/child", parents: ["sg:event/parent"], type: "child" }];
+  // When the future parent is appended as a root.
+  const combined = appendEvent({
+    event: { event_id: "sg:event/parent", parents: [], type: "parent" },
+    events,
+  });
+  // Then both immutable events remain and the child is the sole head.
+  equal(combined.length, 2, "event count");
+  equal(eventHeads({ events: combined }).join(","), "sg:event/child", "heads");
+});
+
+test("append_of_identical_event_is_idempotent", () => {
+  // Given one immutable event already exists.
+  const event = { event_id: "sg:event/root", parents: [], type: "root" };
+  // When the same canonical event is appended again.
+  const combined = appendEvent({ event, events: [event] });
+  // Then no duplicate is created.
+  equal(combined.length, 1, "event count");
+});
+
+const report = {
+  contract: "agent-native-causal-events",
+  ok: cases.every((item) => item.ok),
+  results: cases,
+};
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/test-agent-execution-effects.mjs
+++ b/scripts/test-agent-execution-effects.mjs
@@ -1,0 +1,114 @@
+import {
+  callExport,
+  failFromCall,
+  hasAnyText,
+  isObject,
+  payload,
+  pick,
+  result,
+} from "./test-agent-execution-fixtures.mjs";
+
+export async function exerciseExecutionEffects(modules, state) {
+  const rows = [];
+  const effectCall = await callExport(modules.execution, "execution", "recordEffectAttempt", {
+    attempt: "external-call",
+    connector: "fixture-connector",
+    connectorReceipt: null,
+    effect: "sg:effect/execution-fixture",
+    effectClass: "EXTERNAL",
+    effectId: "sg:effect/execution-fixture",
+    idempotencyKey: "idem:execution-fixture",
+    operation: state.operation,
+    run: state.run,
+    state: "UNCERTAIN",
+    task: state.task,
+  });
+  const uncertain = effectCall.ok ? payload(effectCall.value) : null;
+  rows.push(effectCall.ok
+    ? result(
+      "external_effect_without_receipt_is_uncertain",
+      "an external attempt without durable connector receipt is UNCERTAIN",
+      uncertain,
+      isObject(uncertain) && hasAnyText(uncertain, ["state", "status", "effectState", "effect_state"], ["UNCERTAIN", "uncertain"]),
+    )
+    : failFromCall("external_effect_without_receipt_is_uncertain", "an external attempt without durable connector receipt is UNCERTAIN", effectCall));
+
+  const recoveredCall = await callExport(modules.execution, "execution", "reconcileEffect", {
+    effect: uncertain,
+    observation: { connectorReceipt: "sg:connector-receipt/recovered", status: "COMMITTED" },
+    observations: [{ connectorReceipt: "sg:connector-receipt/recovered", status: "COMMITTED" }],
+    strategy: "reconcile",
+  });
+  const recovered = recoveredCall.ok ? payload(recoveredCall.value) : null;
+  rows.push(recoveredCall.ok
+    ? result(
+      "uncertain_effect_reconciles_from_positive_observation",
+      "positive connector observation yields COMMITTED and preserves receipt",
+      recovered,
+      isObject(recovered)
+        && hasAnyText(recovered, ["state", "status", "effectState", "effect_state"], ["COMMITTED", "committed"])
+        && typeof pick(recovered, ["connectorReceipt", "connector_receipt", "receiptId", "receipt_id"]) === "string",
+    )
+    : failFromCall("uncertain_effect_reconciles_from_positive_observation", "positive connector observation yields COMMITTED and preserves receipt", recoveredCall));
+
+  const compensatedCall = await callExport(modules.execution, "execution", "reconcileEffect", {
+    effect: uncertain,
+    observation: { status: "ABSENT" },
+    observations: [{ status: "ABSENT" }],
+    strategy: "compensate",
+  });
+  const compensated = compensatedCall.ok ? payload(compensatedCall.value) : null;
+  rows.push(compensatedCall.ok
+    ? result(
+      "uncertain_effect_can_be_compensated",
+      "negative connector observation with explicit compensation yields COMPENSATED",
+      compensated,
+      isObject(compensated) && hasAnyText(compensated, ["state", "status", "effectState", "effect_state"], ["COMPENSATED", "compensated"]),
+    )
+    : failFromCall("uncertain_effect_can_be_compensated", "negative connector observation with explicit compensation yields COMPENSATED", compensatedCall));
+
+  const conflictCall = await callExport(modules.execution, "execution", "reconcileEffect", {
+    effect: uncertain,
+    observation: { status: "COMMITTED" },
+    observations: [{ status: "COMMITTED" }, { status: "ABSENT" }],
+    strategy: "reconcile",
+  });
+  const conflict = conflictCall.ok ? payload(conflictCall.value) : null;
+  rows.push(conflictCall.ok
+    ? result(
+      "conflicting_reconciliation_stays_uncertain",
+      "conflicting observations never silently commit or compensate",
+      conflict,
+      isObject(conflict) && hasAnyText(conflict, ["state", "status", "effectState", "effect_state"], ["UNCERTAIN", "uncertain"]),
+    )
+    : failFromCall("conflicting_reconciliation_stays_uncertain", "conflicting observations never silently commit or compensate", conflictCall));
+
+  const receiptCall = await callExport(modules.execution, "execution", "createReceipt", {
+    causalParents: ["sg:event/effect-reconciled"],
+    effect: recovered,
+    effects: [recovered],
+    input: { stableRef: "sg:profile/editorial-reference-profile" },
+    operation: state.operation,
+    output: { stableRef: "sg:profile/editorial-reference-profile", resolved: true },
+    policyDecision: pick(state.authorized, ["decision", "policyDecision", "policy_decision"]) ?? state.authorized,
+    run: state.run,
+    task: state.task,
+  });
+  const receipt = receiptCall.ok ? payload(receiptCall.value) : null;
+  rows.push(receiptCall.ok
+    ? result(
+      "invocation_receipt_binds_operation_task_run_and_effect",
+      "receipt records operation, task/run IDs, normalized input/output digests, policy, effects, and causal parents",
+      receipt,
+      isObject(receipt)
+        && typeof pick(receipt, ["inputDigest", "input_digest", "normalizedInputDigest", "normalized_input_digest"]) === "string"
+        && typeof pick(receipt, ["outputDigest", "output_digest", "normalizedOutputDigest", "normalized_output_digest"]) === "string"
+        && typeof pick(receipt, ["taskId", "task_id"]) === "string"
+        && typeof pick(receipt, ["runId", "run_id"]) === "string"
+        && Array.isArray(pick(receipt, ["effects", "effectIds", "effect_ids"]))
+        && Array.isArray(pick(receipt, ["causalParents", "causal_parents", "parents"])),
+    )
+    : failFromCall("invocation_receipt_binds_operation_task_run_and_effect", "receipt records operation, task/run IDs, normalized input/output digests, policy, effects, and causal parents", receiptCall));
+
+  return { rows, uncertain, recovered, receipt };
+}

--- a/scripts/test-agent-execution-fixtures.mjs
+++ b/scripts/test-agent-execution-fixtures.mjs
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const modulePaths = {
+  execution: path.join(repositoryRoot, "scripts", "agent-native", "execution.mjs"),
+  events: path.join(repositoryRoot, "scripts", "agent-native", "events.mjs"),
+  retrieval: path.join(repositoryRoot, "scripts", "agent-native", "retrieval.mjs"),
+  learning: path.join(repositoryRoot, "scripts", "agent-native", "learning.mjs"),
+};
+
+export const fixedNow = "2026-01-02T03:04:05.000Z";
+export const fixedExpiry = "2030-01-01T00:00:00.000Z";
+
+function sorted(value) {
+  if (Array.isArray(value)) return value.map(sorted);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sorted(value[key])]));
+}
+
+export function bytes(value) {
+  return JSON.stringify(sorted(value));
+}
+
+export function pick(value, keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(value, key) && value[key] !== undefined) return value[key];
+  }
+  return undefined;
+}
+
+export function hasText(value, keys, expected) {
+  const actual = pick(value, keys);
+  return typeof actual === "string" && actual === expected;
+}
+
+export function hasAnyText(value, keys, expectedValues) {
+  const actual = pick(value, keys);
+  return expectedValues.includes(actual);
+}
+
+export function isObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function payload(value) {
+  if (isObject(value) && value.ok === true && Object.prototype.hasOwnProperty.call(value, "result")) {
+    return value.result;
+  }
+  return value;
+}
+
+export async function loadKernelModule(name) {
+  try {
+    const module = await import(pathToFileURL(modulePaths[name]).href);
+    return { ok: true, module };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "kernel_unavailable",
+        module: name,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+export async function callExport(loaded, moduleName, exportName, input) {
+  if (!loaded?.ok) return { ok: false, error: loaded?.error ?? { code: "kernel_unavailable", module: moduleName } };
+  const fn = loaded.module?.[exportName];
+  if (typeof fn !== "function") {
+    return {
+      ok: false,
+      error: { code: "kernel_unavailable", module: moduleName, export: exportName, message: "missing export" },
+    };
+  }
+  try {
+    return { ok: true, value: await fn(input) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: { code: "contract_error", module: moduleName, export: exportName, message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+export function result(name, expected, actual, ok, details = undefined) {
+  const record = { actual, expected, name, ok };
+  if (details !== undefined) record.details = details;
+  return record;
+}
+
+export function failFromCall(name, expected, call) {
+  return result(name, expected, call.error, false);
+}
+
+export function idOf(value, fallback = undefined) {
+  return pick(value, ["versionId", "version_id", "stableRef", "stable_ref", "taskId", "task_id", "runId", "run_id", "effectId", "effect_id", "id"]) ?? fallback;
+}
+
+export function stateOf(value) {
+  return pick(value, ["state", "status", "effectState", "effect_state", "disposition"]);
+}
+
+export function operationInput() {
+  return {
+    adapters: ["cli", "mcp"],
+    effect: "NONE",
+    effectClass: "NONE",
+    idempotent: true,
+    inputSchema: {
+      additionalProperties: false,
+      properties: { stableRef: { type: "string" } },
+      required: ["stableRef"],
+      type: "object",
+    },
+    name: "resolve",
+    operation: "resolve",
+    outputSchema: { type: "object" },
+    requiredCapability: "wiki.read",
+    stableRef: "sg:operation/resolve",
+    version: "v1",
+  };
+}
+
+export function grantInput() {
+  return {
+    capability: "wiki.read",
+    expiresAt: fixedExpiry,
+    limits: { calls: 3, maxCalls: 3 },
+    operation: "resolve",
+    operations: ["resolve", "sg:operation/resolve"],
+    resourceScope: ["sg:profile/*", "sg:claim/*"],
+    resources: ["sg:profile/*", "sg:claim/*"],
+    stableRef: "sg:capability/wiki-read",
+    subject: "agent:test",
+  };
+}

--- a/scripts/test-agent-execution-kernel.mjs
+++ b/scripts/test-agent-execution-kernel.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import {
+  loadKernelModule,
+  modulePaths,
+  result,
+} from "./test-agent-execution-fixtures.mjs";
+import { exerciseExecutionEffects } from "./test-agent-execution-effects.mjs";
+import { exerciseLearning } from "./test-agent-execution-learning.mjs";
+import { exerciseExecutionLifecycle } from "./test-agent-execution-lifecycle.mjs";
+import { exerciseEvents, exerciseRetrieval } from "./test-agent-execution-views.mjs";
+
+async function main() {
+  const unknownArgs = process.argv.slice(2).filter((arg) => arg !== "--json");
+  if (unknownArgs.length > 0) {
+    const report = { ok: false, results: [result("argument_contract", "only --json is accepted", { unknownArgs }, false)] };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const modules = Object.fromEntries(await Promise.all(Object.keys(modulePaths).map(async (name) => [name, await loadKernelModule(name)])));
+  const lifecycle = await exerciseExecutionLifecycle(modules);
+  const effects = await exerciseExecutionEffects(modules, lifecycle);
+  const state = { ...lifecycle, ...effects };
+  const eventRows = await exerciseEvents(modules, state);
+  const retrieval = await exerciseRetrieval(modules);
+  const learningRows = await exerciseLearning(modules, { ...state, ...retrieval });
+  const results = [...lifecycle.rows, ...effects.rows, ...eventRows, ...retrieval.rows, ...learningRows];
+  const report = {
+    contract: "agent-native-execution-kernel",
+    ok: results.length > 0 && results.every((row) => row.ok),
+    results,
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+await main();

--- a/scripts/test-agent-execution-learning.mjs
+++ b/scripts/test-agent-execution-learning.mjs
@@ -1,0 +1,130 @@
+import {
+  bytes,
+  callExport,
+  failFromCall,
+  fixedNow,
+  hasAnyText,
+  idOf,
+  isObject,
+  payload,
+  pick,
+  result,
+  stateOf,
+} from "./test-agent-execution-fixtures.mjs";
+
+export async function exerciseLearning(modules, state) {
+  const rows = [];
+  const proposalInput = {
+    claim: { stableRef: "sg:claim/retrieval-improvement", text: "The fixture retriever preserves citation coverage." },
+    changes: [{ path: "retriever.strategy", value: "hybrid" }],
+    evidence: [{ receiptId: pick(state.receipt, ["receiptId", "receipt_id", "id"]), stableRef: "sg:evidence/execution-fixture" }],
+    proposer: "agent:proposer",
+    proposalId: "sg:proposal/retrieval-improvement",
+    sourceTask: idOf(state.task, "sg:task/execution-fixture"),
+    validation: { status: "PASS", validator: "agent:validator", version: "validator@v1" },
+  };
+  const proposalCall = await callExport(modules.learning, "learning", "createProposal", proposalInput);
+  const proposal = proposalCall.ok ? payload(proposalCall.value) : null;
+  const directPromotionCall = await callExport(modules.learning, "learning", "promoteProposal", { proposal });
+  const directPromotion = directPromotionCall.ok ? payload(directPromotionCall.value) : null;
+  rows.push(directPromotionCall.ok
+    ? result(
+      "promotion_requires_verify_and_decision",
+      "proposal cannot promote before an independent verification and accepted governance decision",
+      directPromotion,
+      !(isObject(directPromotion) && (directPromotion.promoted === true || directPromotion.status === "PROMOTED")),
+    )
+    : failFromCall("promotion_requires_verify_and_decision", "proposal cannot promote before an independent verification and accepted governance decision", directPromotionCall));
+  if (!proposalCall.ok) {
+    rows.push(failFromCall("learning_proposal_is_immutable_and_provenanced", "proposal records claim, evidence, validation, proposer, and proposed change", proposalCall));
+    return rows;
+  }
+  rows.push(result(
+    "learning_proposal_is_immutable_and_provenanced",
+    "proposal records claim, evidence, validation, proposer, and proposed change",
+    proposal,
+    isObject(proposal)
+      && isObject(pick(proposal, ["claim"]))
+      && Array.isArray(pick(proposal, ["evidence", "evidenceLinks", "evidence_links"]))
+      && isObject(pick(proposal, ["validation"]))
+      && typeof pick(proposal, ["proposer", "proposedBy", "proposed_by"]) === "string"
+      && Array.isArray(pick(proposal, ["changes", "patch", "delta"])),
+  ));
+
+  const sameActorCall = await callExport(modules.learning, "learning", "verifyProposal", {
+    proposal,
+    verifier: "agent:proposer",
+    verifierActor: "agent:proposer",
+    evidence: proposalInput.evidence,
+    validation: proposalInput.validation,
+  });
+  const sameActor = sameActorCall.ok ? payload(sameActorCall.value) : null;
+  rows.push(sameActorCall.ok
+    ? result(
+      "learning_verification_requires_independence",
+      "proposer cannot satisfy the independent verification gate",
+      sameActor,
+      !(isObject(sameActor) && (sameActor.verified === true || sameActor.status === "VERIFIED" || sameActor.ok === true)),
+    )
+    : failFromCall("learning_verification_requires_independence", "proposer cannot satisfy the independent verification gate", sameActorCall));
+
+  const verifyCall = await callExport(modules.learning, "learning", "verifyProposal", {
+    independentOf: "agent:proposer",
+    proposal,
+    verifier: "agent:verifier",
+    verifierActor: "agent:verifier",
+    evidence: [{ ...proposalInput.evidence[0], independentGroup: "verification-group" }],
+    validation: { status: "PASS", validator: "agent:validator", version: "validator@v1" },
+  });
+  const verification = verifyCall.ok ? payload(verifyCall.value) : null;
+  rows.push(verifyCall.ok
+    ? result(
+      "learning_verification_is_independent_and_validated",
+      "different actor supplies positive verification with passing validation",
+      verification,
+      isObject(verification)
+        && (pick(verification, ["verified", "isVerified"]) === true || stateOf(verification) === "VERIFIED" || stateOf(verification) === "verified")
+        && typeof pick(verification, ["verifier", "verifiedBy", "verified_by"]) === "string"
+        && pick(verification, ["verifier", "verifiedBy", "verified_by"]) !== pick(proposal, ["proposer", "proposedBy", "proposed_by"]),
+    )
+    : failFromCall("learning_verification_is_independent_and_validated", "different actor supplies positive verification with passing validation", verifyCall));
+
+  const decisionCall = await callExport(modules.learning, "learning", "decideProposal", {
+    decision: "ACCEPT",
+    governanceDecision: { actor: "governor:test", decision: "ACCEPT", scope: "retriever", decidedAt: fixedNow },
+    proposal,
+    verification,
+  });
+  const decision = decisionCall.ok ? payload(decisionCall.value) : null;
+  rows.push(decisionCall.ok
+    ? result(
+      "learning_governance_decision_is_explicit",
+      "promotion is gated by an explicit accepted governance decision",
+      decision,
+      isObject(decision) && hasAnyText(decision, ["decision", "status", "disposition"], ["ACCEPT", "ACCEPTED", "accepted"]),
+    )
+    : failFromCall("learning_governance_decision_is_explicit", "promotion is gated by an explicit accepted governance decision", decisionCall));
+
+  const registryBefore = { entries: [{ stableRef: "sg:retriever/fixture", versionId: "sg:retriever/fixture@sha256:4444444444444444444444444444444444444444444444444444444444444444" }] };
+  const registryDigestBefore = bytes(registryBefore);
+  const promotionCall = await callExport(modules.learning, "learning", "promoteProposal", {
+    decision,
+    governanceDecision: decision,
+    proposal,
+    registry: registryBefore,
+    verification,
+  });
+  const promotion = promotionCall.ok ? payload(promotionCall.value) : null;
+  rows.push(promotionCall.ok
+    ? result(
+      "learning_promotion_never_auto_asserts_truth",
+      "accepted promotion creates a new governed version/receipt without mutating prior registry or asserting factual truth",
+      promotion,
+      isObject(promotion)
+        && (promotion.promoted === true || hasAnyText(promotion, ["status", "state"], ["PROMOTED", "promoted"]))
+        && bytes(registryBefore) === registryDigestBefore
+        && pick(promotion, ["autoTruth", "auto_truth", "truthAccepted", "truth_accepted"]) !== true,
+    )
+    : failFromCall("learning_promotion_never_auto_asserts_truth", "accepted promotion creates a new governed version/receipt without mutating prior registry or asserting factual truth", promotionCall));
+  return rows;
+}

--- a/scripts/test-agent-execution-lifecycle.mjs
+++ b/scripts/test-agent-execution-lifecycle.mjs
@@ -1,0 +1,143 @@
+import {
+  callExport,
+  failFromCall,
+  fixedNow,
+  grantInput,
+  hasAnyText,
+  hasText,
+  idOf,
+  isObject,
+  operationInput,
+  payload,
+  pick,
+  result,
+  stateOf,
+} from "./test-agent-execution-fixtures.mjs";
+
+export async function exerciseExecutionLifecycle(modules) {
+  const rows = [];
+  const operationSpec = operationInput();
+  const grant = grantInput();
+  const operationCall = await callExport(modules.execution, "execution", "defineOperation", operationSpec);
+  const operation = operationCall.ok ? payload(operationCall.value) : null;
+  rows.push(operationCall.ok
+    ? result(
+      "operation_spec_defines_effect_and_capability",
+      "operation has stable identity, NONE effect, idempotency, and required capability",
+      {
+        effectClass: pick(operation, ["effectClass", "effect_class", "effect"]),
+        idempotent: pick(operation, ["idempotent", "isIdempotent"]),
+        requiredCapability: pick(operation, ["requiredCapability", "required_capability", "capability"]),
+        stableRef: pick(operation, ["stableRef", "stable_ref", "operation", "name"]),
+      },
+      isObject(operation)
+        && hasAnyText(operation, ["effectClass", "effect_class", "effect"], ["NONE", "none"])
+        && pick(operation, ["idempotent", "isIdempotent"]) === true
+        && hasText(operation, ["requiredCapability", "required_capability", "capability"], "wiki.read")
+        && typeof pick(operation, ["stableRef", "stable_ref", "operation", "name"]) === "string",
+    )
+    : failFromCall("operation_spec_defines_effect_and_capability", "operation has stable identity, NONE effect, idempotency, and required capability", operationCall));
+
+  const authorizedCall = await callExport(modules.execution, "execution", "authorizeOperation", {
+    capability: grant,
+    grant,
+    now: fixedNow,
+    operation,
+    resource: "sg:profile/editorial-reference-profile",
+    subject: "agent:test",
+  });
+  const authorized = authorizedCall.ok ? payload(authorizedCall.value) : null;
+  rows.push(authorizedCall.ok
+    ? result(
+      "capability_authorizes_scoped_read",
+      "allowed true with a policy decision bound to subject, operation, resource, and time",
+      authorized,
+      isObject(authorized)
+        && pick(authorized, ["allowed", "isAllowed"]) === true
+        && isObject(pick(authorized, ["decision", "policyDecision", "policy_decision"]))
+        && typeof pick(pick(authorized, ["decision", "policyDecision", "policy_decision"]), ["subject", "principal"]) === "string",
+    )
+    : failFromCall("capability_authorizes_scoped_read", "allowed true with a policy decision bound to subject, operation, resource, and time", authorizedCall));
+
+  const deniedCall = await callExport(modules.execution, "execution", "authorizeOperation", {
+    capability: grant,
+    grant,
+    now: fixedNow,
+    operation,
+    resource: "sg:governance/private",
+    subject: "agent:other",
+  });
+  const denied = deniedCall.ok ? payload(deniedCall.value) : null;
+  rows.push(deniedCall.ok
+    ? result(
+      "capability_denies_wrong_subject_and_resource",
+      "allowed false with a stable authorization failure",
+      denied,
+      isObject(denied) && pick(denied, ["allowed", "isAllowed"]) === false,
+    )
+    : failFromCall("capability_denies_wrong_subject_and_resource", "allowed false with a stable authorization failure", deniedCall));
+
+  const taskInput = {
+    intent: { operation: "resolve", resource: "sg:profile/editorial-reference-profile" },
+    operation: "resolve",
+    requiredResult: { type: "profile" },
+    stableRef: "sg:task/execution-fixture",
+    taskId: "sg:task/execution-fixture",
+  };
+  const taskCall = await callExport(modules.execution, "execution", "createTask", taskInput);
+  const task = taskCall.ok ? payload(taskCall.value) : null;
+  rows.push(taskCall.ok
+    ? result(
+      "task_preserves_intent_and_required_result",
+      "task has stable task identity, intent, required result, and initial state",
+      task,
+      isObject(task)
+        && typeof idOf(task, "sg:task/execution-fixture") === "string"
+        && isObject(pick(task, ["intent", "request"]))
+        && isObject(pick(task, ["requiredResult", "required_result", "result"]))
+        && typeof stateOf(task) === "string",
+    )
+    : failFromCall("task_preserves_intent_and_required_result", "task has stable task identity, intent, required result, and initial state", taskCall));
+
+  const runCall = await callExport(modules.execution, "execution", "startRun", {
+    input: { stableRef: "sg:profile/editorial-reference-profile" },
+    runId: "sg:run/execution-fixture-1",
+    run_id: "sg:run/execution-fixture-1",
+    task,
+    taskId: pick(task, ["taskId", "task_id", "stableRef", "stable_ref"]) ?? "sg:task/execution-fixture",
+  });
+  const run = runCall.ok ? payload(runCall.value) : null;
+  rows.push(runCall.ok
+    ? result(
+      "run_belongs_to_one_task",
+      "run has a distinct run identity linked to the task",
+      run,
+      isObject(run)
+        && pick(run, ["runId", "run_id", "stableRef", "stable_ref", "id"]) === "sg:run/execution-fixture-1"
+        && pick(run, ["taskId", "task_id"]) === (pick(task, ["taskId", "task_id", "stableRef", "stable_ref"]) ?? "sg:task/execution-fixture")
+        && typeof stateOf(run) === "string",
+    )
+    : failFromCall("run_belongs_to_one_task", "run has a distinct run identity linked to the task", runCall));
+
+  const immediateAuthCall = await callExport(modules.execution, "execution", "authorizeEffect", {
+    capability: grant,
+    grant,
+    now: fixedNow,
+    operation,
+    resource: "sg:profile/editorial-reference-profile",
+    run,
+    subject: "agent:test",
+    task,
+  });
+  const immediateAuth = immediateAuthCall.ok ? payload(immediateAuthCall.value) : null;
+  rows.push(immediateAuthCall.ok
+    ? result(
+      "effect_rechecks_authorization_immediately",
+      "effect authorization is explicitly allowed immediately before an external attempt",
+      immediateAuth,
+      isObject(immediateAuth) && pick(immediateAuth, ["allowed", "isAllowed"]) === true,
+    )
+    : failFromCall("effect_rechecks_authorization_immediately", "effect authorization is explicitly allowed immediately before an external attempt", immediateAuthCall));
+
+  return { rows, operation, grant, task, run, authorized };
+}

--- a/scripts/test-agent-execution-safety.mjs
+++ b/scripts/test-agent-execution-safety.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import {
+  authorizeOperation,
+  defineOperation,
+  reconcileEffect,
+  recordEffectAttempt,
+} from "./agent-native/execution.mjs";
+
+const cases = [];
+
+function test(name, scenario) {
+  try {
+    scenario();
+    cases.push({ name, ok: true });
+  } catch (error) {
+    cases.push({
+      error: error instanceof Error ? error.message : String(error),
+      name,
+      ok: false,
+    });
+  }
+}
+
+function equal(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: expected ${expected}, received ${actual}`);
+}
+
+function operation() {
+  return defineOperation({
+    effect_class: "EXTERNAL",
+    name: "publish",
+    required_capability: "wiki.publish",
+    stable_ref: "sg:operation/publish",
+  });
+}
+
+function grant(operations) {
+  return {
+    capability: "wiki.publish",
+    operations,
+    resource_scope: ["sg:profile/*"],
+    subject: "agent:test",
+  };
+}
+
+function authorization(operations) {
+  return authorizeOperation({
+    grant: grant(operations),
+    operation: operation(),
+    resource: "sg:profile/editorial-reference-profile",
+    subject: "agent:test",
+  });
+}
+
+function externalEffect(overrides = {}) {
+  return recordEffectAttempt({
+    effect_class: "EXTERNAL",
+    effect_id: "sg:effect/publish-1",
+    run_id: "sg:run/publish-1",
+    task_id: "sg:task/publish-1",
+    ...overrides,
+  });
+}
+
+test("empty_operation_scope_denies_protected_operation", () => {
+  // Given a capability with matching subject, resource, and capability but no operations.
+  // When authorization evaluates the protected publish operation.
+  const result = authorization([]);
+  // Then omission is deny-by-default rather than a wildcard grant.
+  equal(result.allowed, false, "allowed");
+  equal(result.failures.includes("operation_denied"), true, "operation_denied");
+});
+
+test("explicit_operation_scope_authorizes_matching_operation", () => {
+  // Given an explicitly scoped capability.
+  // When the named operation is evaluated.
+  const result = authorization(["publish"]);
+  // Then the operation is authorized.
+  equal(result.allowed, true, "allowed");
+});
+
+test("external_effect_ignores_forged_committed_state_without_receipt", () => {
+  // Given an external attempt with no connector receipt and caller state COMMITTED.
+  // When the attempt is recorded.
+  const effect = externalEffect({ connector_receipt: null, state: "COMMITTED" });
+  // Then the kernel derives UNCERTAIN.
+  equal(effect.state, "UNCERTAIN", "state");
+});
+
+test("empty_connector_receipt_cannot_commit_external_effect", () => {
+  // Given an external attempt with an empty receipt identifier.
+  // When the caller requests COMMITTED.
+  const effect = externalEffect({ connector_receipt: "", state: "COMMITTED" });
+  // Then empty evidence is treated as absent.
+  equal(effect.state, "UNCERTAIN", "state");
+});
+
+test("blank_connector_receipt_cannot_commit_external_effect", () => {
+  // Given an external attempt with only whitespace as receipt evidence.
+  // When the caller requests COMMITTED.
+  const effect = externalEffect({ connector_receipt: "   ", state: "COMMITTED" });
+  // Then blank evidence is treated as absent.
+  equal(effect.state, "UNCERTAIN", "state");
+});
+
+test("durable_receipt_commits_external_effect", () => {
+  // Given an external attempt backed by a durable connector receipt ID.
+  // When the caller supplies a conflicting state.
+  const effect = externalEffect({ connector_receipt: "sg:connector-receipt/publish-1", state: "UNCERTAIN" });
+  // Then receipt evidence, not caller state, derives COMMITTED.
+  equal(effect.state, "COMMITTED", "state");
+});
+
+test("positive_observation_without_receipt_stays_uncertain", () => {
+  // Given an uncertain external effect and an unreceipted positive observation.
+  // When reconciliation runs.
+  const reconciled = reconcileEffect({
+    effect: externalEffect(),
+    observations: [{ status: "COMMITTED" }],
+  });
+  // Then status alone cannot commit the effect.
+  equal(reconciled.state, "UNCERTAIN", "state");
+});
+
+test("positive_receipted_observation_commits", () => {
+  // Given an uncertain effect and a positive durable receipt observation.
+  // When reconciliation runs.
+  const reconciled = reconcileEffect({
+    effect: externalEffect(),
+    observations: [{ connector_receipt: "sg:connector-receipt/recovered", status: "COMMITTED" }],
+  });
+  // Then the effect is committed and bound to that receipt.
+  equal(reconciled.state, "COMMITTED", "state");
+  equal(reconciled.connector_receipt, "sg:connector-receipt/recovered", "connector_receipt");
+});
+
+test("legacy_unreceipted_committed_effect_is_demoted", () => {
+  // Given legacy data claiming COMMITTED without receipt evidence.
+  // When it is reconciled without new observations.
+  const reconciled = reconcileEffect({
+    effect: {
+      effect_class: "EXTERNAL",
+      effect_id: "sg:effect/legacy",
+      state: "COMMITTED",
+    },
+  });
+  // Then reconciliation restores the safe UNCERTAIN state.
+  equal(reconciled.state, "UNCERTAIN", "state");
+});
+
+const report = {
+  contract: "agent-native-execution-safety",
+  ok: cases.every((item) => item.ok),
+  results: cases,
+};
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/test-agent-execution-views.mjs
+++ b/scripts/test-agent-execution-views.mjs
@@ -1,0 +1,117 @@
+import {
+  bytes,
+  callExport,
+  failFromCall,
+  fixedNow,
+  idOf,
+  isObject,
+  payload,
+  pick,
+  result,
+} from "./test-agent-execution-fixtures.mjs";
+
+export async function exerciseEvents(modules, state) {
+  const rows = [];
+  let events = [];
+  const entries = [
+    { eventId: "sg:event/task-created", parents: [], payload: { taskId: idOf(state.task, "sg:task/execution-fixture") }, type: "task.created" },
+    { eventId: "sg:event/run-started", parents: ["sg:event/task-created"], payload: { runId: idOf(state.run, "sg:run/execution-fixture-1") }, type: "run.started" },
+    { eventId: "sg:event/effect-reconciled", parents: ["sg:event/task-created"], payload: { effectState: "COMMITTED" }, type: "effect.reconciled" },
+  ];
+  for (const event of entries) {
+    const call = await callExport(modules.events, "events", "appendEvent", { event, events });
+    if (!call.ok) {
+      rows.push(failFromCall("event_dag_append_is_immutable", "appendEvent returns an append-only event collection", call));
+      return rows;
+    }
+    const value = payload(call.value);
+    if (Array.isArray(value)) events = value;
+    else if (Array.isArray(value?.events)) events = value.events;
+    else if (isObject(value?.event)) events = [...events, value.event];
+    else if (isObject(value)) events = [...events, value];
+    else events = [...events, event];
+  }
+  const appendResult = events.map((event) => ({ id: pick(event, ["eventId", "event_id", "id", "stableRef", "stable_ref"]), parents: pick(event, ["parents", "parentIds", "parent_ids"]) }));
+  rows.push(result(
+    "event_dag_append_is_immutable",
+    "three immutable events preserve explicit parent links and event IDs",
+    appendResult,
+    events.length === 3
+      && appendResult.every((event) => typeof event.id === "string" && Array.isArray(event.parents))
+      && appendResult[1].parents.includes("sg:event/task-created")
+      && appendResult[2].parents.includes("sg:event/task-created"),
+  ));
+
+  const headsCall = await callExport(modules.events, "events", "eventHeads", { events });
+  if (!headsCall.ok) {
+    rows.push(failFromCall("event_dag_heads_are_deterministic", "eventHeads returns the two concurrent heads in stable order", headsCall));
+    return rows;
+  }
+  const heads = payload(headsCall.value);
+  const headValues = Array.isArray(heads) ? heads : pick(heads, ["heads", "eventHeads", "event_heads"]);
+  rows.push(result(
+    "event_dag_heads_are_deterministic",
+    "eventHeads returns the two concurrent heads in stable order",
+    headValues,
+    Array.isArray(headValues)
+      && headValues.length === 2
+      && headValues.map(String).sort().join(",") === "sg:event/effect-reconciled,sg:event/run-started",
+  ));
+  return rows;
+}
+
+export async function exerciseRetrieval(modules) {
+  const rows = [];
+  const members = [
+    { content: "Editorial profile uses constrained columns.", stableRef: "sg:profile/editorial-reference-profile", versionId: "sg:profile/editorial-reference-profile@sha256:1111111111111111111111111111111111111111111111111111111111111111" },
+    { content: "Resolve returns governed profile metadata.", stableRef: "sg:claim/resolve-profile", versionId: "sg:claim/resolve-profile@sha256:2222222222222222222222222222222222222222222222222222222222222222" },
+  ];
+  const snapshotInput = {
+    asOf: fixedNow,
+    builderVersion: "retriever-fixture@1",
+    heads: ["sg:event/effect-reconciled", "sg:event/run-started"],
+    members,
+    policy: "sg:governance/read-policy@sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    viewSpec: { queryClass: "exact", stableRef: "sg:view/profile-context", version: "v1" },
+  };
+  const snapshotCallA = await callExport(modules.retrieval, "retrieval", "buildViewSnapshot", snapshotInput);
+  const snapshotCallB = await callExport(modules.retrieval, "retrieval", "buildViewSnapshot", { ...snapshotInput, members: [...members].reverse(), heads: [...snapshotInput.heads].reverse() });
+  const snapshotA = snapshotCallA.ok ? payload(snapshotCallA.value) : null;
+  const snapshotB = snapshotCallB.ok ? payload(snapshotCallB.value) : null;
+  if (!snapshotCallA.ok) rows.push(failFromCall("retrieval_snapshot_is_deterministic", "same inputs produce byte-identical snapshot", snapshotCallA));
+  else if (!snapshotCallB.ok) rows.push(failFromCall("retrieval_snapshot_is_deterministic", "same inputs produce byte-identical snapshot", snapshotCallB));
+  else rows.push(result(
+    "retrieval_snapshot_is_deterministic",
+    "same logical inputs produce byte-identical immutable snapshot with provenance",
+    { first: snapshotA, second: snapshotB, equal: bytes(snapshotA) === bytes(snapshotB) },
+    bytes(snapshotA) === bytes(snapshotB)
+      && isObject(snapshotA)
+      && typeof pick(snapshotA, ["versionId", "version_id", "snapshotRef", "snapshot_ref", "digest", "sha256"]) === "string"
+      && Array.isArray(pick(snapshotA, ["members", "entries", "items"])),
+  ));
+
+  const contextCall = await callExport(modules.retrieval, "retrieval", "buildContextPackage", {
+    budget: { tokens: 240 },
+    members,
+    policy: snapshotInput.policy,
+    queryClass: "exact",
+    query: "Which profile is editorial?",
+    retriever: "retriever:fixture@v1",
+    snapshot: snapshotA,
+  });
+  const context = contextCall.ok ? payload(contextCall.value) : null;
+  rows.push(contextCall.ok
+    ? result(
+      "context_package_is_bounded_and_provenance_linked",
+      "context package preserves snapshot/policy/member manifest and token budget",
+      context,
+      isObject(context)
+        && isObject(pick(context, ["budget"]))
+        && Number.isInteger(pick(pick(context, ["budget"]), ["tokens", "tokenBudget", "token_budget"]))
+        && Array.isArray(pick(context, ["members", "entries", "items"]))
+        && pick(context, ["snapshot", "snapshotRef", "snapshot_ref"]) !== undefined
+        && pick(context, ["policy", "policyRef", "policy_ref"]) !== undefined,
+    )
+    : failFromCall("context_package_is_bounded_and_provenance_linked", "context package preserves snapshot/policy/member manifest and token budget", contextCall));
+  return { rows, snapshot: snapshotA, context };
+}

--- a/scripts/test-agent-identity-integrity-cases.mjs
+++ b/scripts/test-agent-identity-integrity-cases.mjs
@@ -1,0 +1,160 @@
+import { createHash } from "node:crypto";
+import { canonicalize, hashCanonical } from "./agent-native/canonical-json.mjs";
+import {
+  createManifest,
+  createStableRef,
+  createVersionId,
+  parseStableRef,
+  parseVersionId,
+  verifyManifest,
+} from "./agent-native/identity.mjs";
+import { createImmutableStore } from "./agent-native/immutable-store.mjs";
+
+class IntegrityAssertionError extends Error {
+  constructor(message) {
+    super(message);
+    this.code = "assertion_failed";
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new IntegrityAssertionError(message);
+}
+
+function expectCode(execute, code, message) {
+  try {
+    execute();
+  } catch (error) {
+    assert(error?.code === code, `${message}: expected ${code}, got ${error?.code}`);
+    return error.code;
+  }
+  throw new IntegrityAssertionError(`${message}: operation succeeded`);
+}
+
+async function runCase(name, expected, execute) {
+  try {
+    return { actual: await execute(), expected, name, ok: true };
+  } catch (error) {
+    return {
+      actual: {
+        code: error?.code ?? "integrity_case_exception",
+        message: error instanceof Error ? error.message : String(error),
+        ...(error?.path ? { path: error.path } : {}),
+      },
+      expected,
+      name,
+      ok: false,
+    };
+  }
+}
+
+function versioned(stable_ref, content) {
+  return { ...content, stable_ref, version_id: createVersionId({ stable_ref, payload: content }) };
+}
+
+export async function runIdentityIntegrityCases() {
+  const results = [];
+  results.push(await runCase("canonical_json_is_recursive_and_deterministic", "keys sorted recursively", () => {
+    const bytes = canonicalize({ z: 2, a: { z: false, b: 1 }, m: [3, { y: 1, x: 0 }] });
+    assert(bytes === '{"a":{"b":1,"z":false},"m":[3,{"x":0,"y":1}],"z":2}', `unexpected canonical bytes: ${bytes}`);
+    const hashBytes = canonicalize({ b: 2, a: 1 });
+    const digest = hashCanonical({ b: 2, a: 1 }).slice("sha256:".length);
+    assert(digest === createHash("sha256").update(hashBytes).digest("hex"), "canonical hash does not match canonical UTF-8 bytes");
+    return { bytes, digest };
+  }));
+  results.push(await runCase("stable_ref_grammar_and_round_trip", "governed StableRef round-trips", () => {
+    const stable_ref = createStableRef({ kind: "claim", id: "editorial-layout" });
+    assert(parseStableRef(stable_ref).id === "editorial-layout", "opaque id was not parsed");
+    expectCode(() => parseStableRef("claim/editorial layout"), "stable_ref_invalid", "malformed StableRef accepted");
+    return { stable_ref };
+  }));
+  results.push(await runCase("version_id_binds_domain_identity_and_all_content", "StableRef and domain id alter digest", () => {
+    const first = createVersionId({ stable_ref: "sg:claim/shared", id: "alpha", statement: "same" });
+    const reordered = createVersionId({ statement: "same", id: "alpha", stable_ref: "sg:claim/shared" });
+    const second = createVersionId({ stable_ref: "sg:claim/shared", id: "beta", statement: "same" });
+    const otherRef = createVersionId({ stable_ref: "sg:claim/other", id: "alpha", statement: "same" });
+    assert(first === reordered, "VersionID depends on object key order");
+    assert(first !== second, "records differing only by domain id collided");
+    assert(first.split("@sha256:")[1] !== otherRef.split("@sha256:")[1], "StableRef was absent from digest input");
+    const parsed = parseVersionId({ version_id: first, stable_ref: "sg:claim/shared", payload: { id: "alpha", statement: "same" } });
+    assert(parsed.stable_ref === "sg:claim/shared", "VersionID lost its StableRef");
+    const parsedString = parseVersionId(first);
+    assert(parsedString.version_id === first && parsedString.stable_ref === "sg:claim/shared", "raw VersionID string did not round-trip");
+    expectCode(
+      () => parseVersionId({ version_id: first, payload: { id: "beta", statement: "same" } }),
+      "version_digest_mismatch",
+      "changed domain id verified",
+    );
+    return { first, second, other_ref: otherRef };
+  }));
+  results.push(await runCase("immutable_store_rehashes_every_append", "forged and altered records are rejected", () => {
+    const store = createImmutableStore();
+    const valid = versioned("sg:claim/store-fixture", { id: "alpha", nested: { value: "original" } });
+    const inserted = store.append(valid);
+    assert(Object.isFrozen(inserted) && Object.isFrozen(inserted.nested), "stored record is not deeply frozen");
+    try { inserted.nested.value = "tampered"; } catch { /* frozen ESM records throw */ }
+    assert(inserted.nested.value === "original", "stored nested bytes were mutable");
+    expectCode(
+      () => store.append({ ...valid, stable_ref: "sg:claim/forged", version_id: `sg:claim/forged@sha256:${"0".repeat(64)}` }),
+      "version_digest_mismatch",
+      "forged VersionID accepted",
+    );
+    expectCode(
+      () => store.append({ ...valid, nested: { value: "tampered" } }),
+      "version_digest_mismatch",
+      "altered bytes accepted under an existing VersionID",
+    );
+    return { size: store.size, version_id: valid.version_id };
+  }));
+  results.push(await runCase("manifest_binds_version_digest_content_digest_and_content", "inline content is checked three ways", () => {
+    const alphaContent = { id: "alpha", statement: "A" };
+    const zetaContent = { id: "zeta", statement: "Z" };
+    const entry = (stable_ref, content) => ({
+      stable_ref,
+      content,
+      content_sha256: hashCanonical(content).slice("sha256:".length),
+      version_id: createVersionId({ stable_ref, payload: content }),
+    });
+    const manifest = createManifest({
+      manifest_ref: "sg:manifest/identity-fixture",
+      entries: [entry("sg:claim/zeta", zetaContent), entry("sg:claim/alpha", alphaContent)],
+    });
+    assert(manifest.entries[0].stable_ref === "sg:claim/alpha", "entries were not sorted");
+    assert(new Set(manifest.entries.map(({ stable_ref }) => stable_ref)).size === manifest.entries.length, "entries were not unique");
+    assert(verifyManifest(manifest).ok, "fresh content-backed manifest failed verification");
+    expectCode(
+      () => createManifest({ manifest_ref: "sg:manifest/identity-fixture", entries: [entry("sg:claim/alpha", alphaContent), entry("sg:claim/alpha", alphaContent)] }),
+      "manifest_entry_duplicate",
+      "duplicate StableRefs accepted",
+    );
+    expectCode(
+      () => createManifest({ manifest_ref: "sg:manifest/identity-fixture", entries: [{ ...entry("sg:claim/alpha", alphaContent), content: { id: "beta", statement: "A" } }] }),
+      "version_digest_mismatch",
+      "VersionID unrelated to inline content accepted",
+    );
+    expectCode(
+      () => createManifest({ manifest_ref: "sg:manifest/identity-fixture", entries: [{ ...entry("sg:claim/alpha", alphaContent), content_sha256: "1".repeat(64) }] }),
+      "manifest_content_digest_mismatch",
+      "content digest unrelated to inline content accepted",
+    );
+    expectCode(
+      () => createManifest({ manifest_ref: "sg:manifest/identity-fixture", entries: [{ ...entry("sg:claim/alpha", alphaContent), content: { ...alphaContent, stable_ref: "sg:claim/zeta" } }] }),
+      "manifest_content_ref_mismatch",
+      "content carrying a different StableRef accepted",
+    );
+    expectCode(
+      () => createManifest({ manifest_ref: "sg:manifest/identity-fixture", entries: [{ ...entry("sg:claim/alpha", alphaContent), content: { ...alphaContent, version_id: `sg:claim/alpha@sha256:${"0".repeat(64)}` } }] }),
+      "manifest_content_version_mismatch",
+      "content carrying a different VersionID accepted",
+    );
+    const tampered = structuredClone(manifest);
+    tampered.entries[0].content.statement = "tampered";
+    const verification = verifyManifest(tampered);
+    assert(!verification.ok && verification.failures.some(({ code }) => code === "version_digest_mismatch"), "tampered inline content verified");
+    const digestTampered = structuredClone(manifest);
+    digestTampered.sha256 = "0".repeat(64);
+    assert(!verifyManifest(digestTampered).ok, "tampered manifest digest verified");
+    return { entries: manifest.entries.length, version_id: manifest.version_id };
+  }));
+  return results;
+}

--- a/scripts/test-agent-knowledge-kernel.mjs
+++ b/scripts/test-agent-knowledge-kernel.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runIdentityIntegrityCases } from "./test-agent-identity-integrity-cases.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const moduleFiles = Object.freeze({
+  canonical: "scripts/agent-native/canonical-json.mjs",
+  identity: "scripts/agent-native/identity.mjs",
+  store: "scripts/agent-native/immutable-store.mjs",
+  knowledge: "scripts/agent-native/knowledge.mjs",
+});
+
+function failure(code, message, recordPath) {
+  return { code, message, ...(recordPath ? { path: recordPath } : {}) };
+}
+
+function valueAt(record, ...keys) {
+  for (const key of keys) {
+    if (record && Object.hasOwn(record, key)) return record[key];
+  }
+  return undefined;
+}
+
+class ContractError extends Error {
+  constructor(code, message, recordPath) {
+    super(message);
+    this.code = code;
+    this.path = recordPath;
+  }
+}
+
+function requireExport(modules, moduleName, names) {
+  const moduleRecord = modules[moduleName];
+  if (!moduleRecord || moduleRecord.error) {
+    const detail = moduleRecord?.error?.message ?? "module was not loaded";
+    throw new ContractError("kernel_module_missing", `${moduleFiles[moduleName]} is unavailable: ${detail}`, moduleFiles[moduleName]);
+  }
+  for (const name of names) {
+    if (typeof moduleRecord.value?.[name] === "function") return moduleRecord.value[name];
+  }
+  throw new ContractError("kernel_export_missing", `${moduleFiles[moduleName]} must export one of ${names.join(", ")}`, moduleFiles[moduleName]);
+}
+
+function assert(condition, message, recordPath) {
+  if (!condition) throw new ContractError("assertion_failed", message, recordPath);
+}
+
+function resultState(result) {
+  const state = valueAt(result, "state", "evidence_state", "aggregation", "status");
+  return typeof state === "string" ? state.toUpperCase() : state;
+}
+
+function makeFixture(modules) {
+  const claimFactory = requireExport(modules, "knowledge", ["createClaim", "makeClaim"]);
+  const evidenceFactory = requireExport(modules, "knowledge", ["createEvidenceLink", "makeEvidenceLink"]);
+  const validationFactory = requireExport(modules, "knowledge", ["createValidationReport", "makeValidationReport"]);
+  const governanceFactory = requireExport(modules, "knowledge", ["createGovernanceDecision", "makeGovernanceDecision"]);
+  const claim = claimFactory({
+    stable_ref: "sg:claim/editorial-layout",
+    statement: "Editorial layout keeps reading order stable.",
+    subject: "sg:profile/editorial-reference-profile",
+    actor: "sg:agent/fixture",
+  });
+  const evidence = (polarity, suffix) => evidenceFactory({
+    stable_ref: `sg:evidence/editorial-layout-${suffix}`,
+    claim_ref: valueAt(claim, "stable_ref", "stableRef") ?? "sg:claim/editorial-layout",
+    claim_version: valueAt(claim, "version_id", "versionId"),
+    source_ref: "sg:artifact/editorial-layout-fixture",
+    source_version: "sg:artifact/editorial-layout-fixture@sha256:" + "1".repeat(64),
+    polarity,
+    independence_group: `fixture-${suffix}`,
+    actor: `sg:observer/${suffix}`,
+  });
+  const validation = validationFactory({
+    stable_ref: "sg:validation/editorial-layout-pass",
+    claim_ref: valueAt(claim, "stable_ref", "stableRef"),
+    claim_version: valueAt(claim, "version_id", "versionId"),
+    validator: "sg:validator/fixture",
+    validator_version: "sg:validator/fixture@sha256:" + "2".repeat(64),
+    status: "PASSED",
+    inputs: [valueAt(claim, "version_id", "versionId")],
+  });
+  const governance = governanceFactory({
+    stable_ref: "sg:governance/editorial-layout-accept",
+    claim_ref: valueAt(claim, "stable_ref", "stableRef"),
+    claim_version: valueAt(claim, "version_id", "versionId"),
+    actor: "sg:governor/fixture",
+    decision: "ACCEPTED",
+    scope: "fixture",
+    policy_version: "sg:governance-policy/fixture@sha256:" + "3".repeat(64),
+  });
+  return { claim, evidence, evidence_sample: evidence("SUPPORT", "fixture"), validation, governance };
+}
+
+async function loadModules() {
+  const modules = {};
+  for (const [name, relative] of Object.entries(moduleFiles)) {
+    try {
+      modules[name] = { value: await import(path.join(root, relative)) };
+    } catch (error) {
+      modules[name] = { error: error instanceof Error ? error : new Error(String(error)) };
+    }
+  }
+  return modules;
+}
+
+async function runCase(name, expected, execute) {
+  try {
+    const actual = await execute();
+    return { actual, expected, name, ok: true };
+  } catch (error) {
+    return {
+      actual: {
+        code: error instanceof ContractError ? error.code : "kernel_case_exception",
+        message: error instanceof Error ? error.message : String(error),
+        ...(error?.path ? { path: error.path } : {}),
+      },
+      expected,
+      name,
+      ok: false,
+    };
+  }
+}
+
+async function main() {
+  const unsupported = process.argv.slice(2).filter((argument) => argument !== "--json");
+  if (unsupported.length > 0) {
+    const report = { ok: false, status: "RED", failures: [failure("argument_unknown", `unknown argument ${unsupported[0]}`)], results: [] };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const modules = await loadModules();
+  const aggregate = () => requireExport(modules, "knowledge", ["aggregateEvidence", "aggregateEvidenceState"]);
+
+  const results = await runIdentityIntegrityCases();
+  results.push(await runCase("claim_evidence_validation_governance_are_distinct_frozen_objects", "each epistemic object has its own immutable identity and lifecycle", () => {
+    const fixture = makeFixture(modules);
+    for (const [name, value] of Object.entries(fixture)) {
+      if (name === "evidence") continue;
+      assert(value && typeof value === "object" && Object.isFrozen(value), `${name} is not deeply frozen`);
+      assert(typeof valueAt(value, "stable_ref", "stableRef") === "string", `${name} has no StableRef`);
+      assert(typeof valueAt(value, "version_id", "versionId") === "string", `${name} has no VersionID`);
+    }
+    assert(fixture.claim !== fixture.validation && fixture.claim !== fixture.governance, "knowledge layers were conflated");
+    return { refs: Object.fromEntries(Object.entries(fixture).map(([name, value]) => [name, valueAt(value, "stable_ref", "stableRef")])) };
+  }));
+  for (const [name, expectedState, links] of [["supported", "SUPPORTED", ["SUPPORT"]], ["refuted", "REFUTED", ["REFUTE"]], ["both", "BOTH", ["SUPPORT", "REFUTE"]], ["neither", "NEITHER", []]]) {
+    results.push(await runCase(`evidence_aggregation_${name}`, `aggregation is ${expectedState}`, () => {
+      const fixture = makeFixture(modules);
+      const evidence = links.map((polarity, index) => fixture.evidence(polarity, `${name}-${index}`));
+      const value = aggregate()({ claim: fixture.claim, evidence_links: evidence, evidenceLinks: evidence });
+      assert(resultState(value) === expectedState, `expected ${expectedState}, got ${resultState(value)}`);
+      return { state: resultState(value) };
+    }));
+  }
+  results.push(await runCase("validation_and_governance_do_not_erase_contradiction", "validation approval and governance acceptance remain separate from BOTH evidence", () => {
+    const fixture = makeFixture(modules);
+    const evidence = [fixture.evidence("SUPPORT", "contradiction-support"), fixture.evidence("REFUTE", "contradiction-refute")];
+    const before = resultState(aggregate()({ claim: fixture.claim, evidence_links: evidence, evidenceLinks: evidence }));
+    assert(before === "BOTH", `contradiction fixture did not aggregate BOTH: ${before}`);
+    assert(valueAt(fixture.validation, "status") === "PASSED", "validation fixture is not passed");
+    assert(valueAt(fixture.governance, "decision", "status") === "ACCEPTED", "governance fixture is not accepted");
+    const after = resultState(aggregate()({ claim: fixture.claim, evidence_links: evidence, evidenceLinks: evidence }));
+    assert(after === "BOTH", `validation/governance erased contradiction: ${after}`);
+    return { before, after, validation: valueAt(fixture.validation, "status"), governance: valueAt(fixture.governance, "decision", "status") };
+  }));
+
+  const ok = results.every((result) => result.ok);
+  const report = {
+    ok,
+    status: ok ? "GREEN" : "RED",
+    modules: Object.fromEntries(Object.entries(modules).map(([name, loaded]) => [name, loaded.error ? { ok: false, error: loaded.error.message } : { ok: true }])),
+    results,
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = ok ? 0 : 1;
+}
+
+await main();

--- a/scripts/test-agent-learning.mjs
+++ b/scripts/test-agent-learning.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import { createVersionId, parseVersionId } from "./agent-native/identity.mjs";
+import {
+  createProposal,
+  decideProposal,
+  promoteProposal,
+  verifyProposal,
+} from "./agent-native/learning.mjs";
+
+function omitVersion(record) {
+  const payload = structuredClone(record);
+  delete payload.version_id;
+  delete payload.versionId;
+  return payload;
+}
+
+function reversion(record, changes) {
+  const payload = { ...omitVersion(record), ...changes };
+  return {
+    ...payload,
+    version_id: createVersionId({ stable_ref: payload.stable_ref, payload }),
+  };
+}
+
+function isVersioned(record, kind) {
+  if (!record || record.record_kind !== kind || typeof record.version_id !== "string") return false;
+  try {
+    parseVersionId({
+      payload: omitVersion(record),
+      stable_ref: record.stable_ref,
+      version_id: record.version_id,
+    });
+    return Object.isFrozen(record);
+  } catch {
+    return false;
+  }
+}
+
+function rejected(call) {
+  try {
+    const value = call();
+    return value?.promoted !== true && (value?.ok === false || value?.status === "BLOCKED");
+  } catch (error) {
+    return typeof error?.code === "string" && error.code.startsWith("learning_");
+  }
+}
+
+function result(id, ok, detail) {
+  return { id, ok, detail };
+}
+
+const proposalInput = {
+  claim: {
+    stable_ref: "sg:claim/retrieval-improvement",
+    text: "The retriever preserves citation coverage.",
+  },
+  changes: [{ path: "retriever.strategy", value: "hybrid" }],
+  evidence: [{
+    independence_group: "capture-a",
+    source_ref: "sg:source/execution-fixture",
+    stable_ref: "sg:evidence/retrieval-proposal",
+  }],
+  proposer: "agent:proposer",
+  proposal_id: "sg:proposal/retrieval-improvement",
+  source_task: "sg:task/execution-fixture",
+  validation: {
+    status: "PASS",
+    validator: "agent:proposal-validator",
+    validator_version: "validator@v1",
+  },
+};
+
+const proposal = createProposal(proposalInput);
+const verification = verifyProposal({
+  evidence: [{
+    independence_group: "capture-b",
+    source_ref: "sg:source/independent-fixture",
+    stable_ref: "sg:evidence/retrieval-verification",
+  }],
+  independent_of: "agent:proposer",
+  proposal,
+  validation: {
+    status: "PASS",
+    validator: "agent:independent-validator",
+    validator_version: "validator@v2",
+  },
+  verifier: "agent:verifier",
+});
+const decision = decideProposal({
+  decision: "ACCEPT",
+  governance_decision: {
+    actor: "governor:review-board",
+    decided_at: "2026-07-23T00:00:00.000Z",
+  },
+  proposal,
+  verification,
+});
+
+const validPromotion = promoteProposal({
+  governance_decision: decision,
+  proposal,
+  verification,
+});
+const proposalV2 = createProposal({
+  ...proposalInput,
+  changes: [{ path: "retriever.strategy", value: "semantic" }],
+});
+const forgedProposal = {
+  ...structuredClone(proposal),
+  changes: [{ path: "retriever.strategy", value: "forged" }],
+};
+const forgedVerification = {
+  ...structuredClone(verification),
+  verifier: "agent:forger",
+  verifier_actor: "agent:forger",
+};
+const wrongKindVerification = reversion(verification, {
+  record_kind: "evidence_link",
+});
+const wrongLinkDecision = reversion(decision, {
+  verification_ref: "sg:validation/unrelated-verification",
+});
+const wrongKindDecision = reversion(decision, {
+  record_kind: "learning_verification",
+});
+const forgedDecision = {
+  ...structuredClone(decision),
+  actor: "governor:forger",
+};
+const aliasInjectedDecision = {
+  ...structuredClone(decision),
+  versionId: `sg:governance/alias@sha256:${"0".repeat(64)}`,
+};
+const tamperedEvidence = structuredClone(verification.evidence);
+tamperedEvidence[0].source_ref = "sg:source/tampered-fixture";
+const verificationWithTamperedEvidence = reversion(verification, {
+  evidence: tamperedEvidence,
+});
+
+const rows = [
+  result(
+    "immutable_chain_is_fully_versioned",
+    isVersioned(proposal, "learning_proposal")
+      && proposal.evidence.every((item) => isVersioned(item, "evidence_link"))
+      && isVersioned(proposal.validation, "validation_report")
+      && isVersioned(verification, "learning_verification")
+      && verification.evidence.every((item) => isVersioned(item, "evidence_link"))
+      && isVersioned(verification.validation, "validation_report")
+      && isVersioned(decision, "governance_decision")
+      && decision.proposal_version_id === proposal.version_id
+      && decision.verification_version_id === verification.version_id,
+    "proposal, evidence, validation, verification, and decision have content-bound VersionIDs",
+  ),
+  result(
+    "valid_independent_chain_promotes",
+    validPromotion.promoted === true
+      && isVersioned(validPromotion.version, "governed_version")
+      && validPromotion.version.proposal_version_id === proposal.version_id
+      && validPromotion.version.verification_version_id === verification.version_id
+      && validPromotion.version.governance_decision_version_id === decision.version_id,
+    "a correctly linked independent chain produces one governed version",
+  ),
+  result(
+    "self_verification_is_rejected",
+    rejected(() => verifyProposal({
+      evidence: proposalInput.evidence,
+      proposal,
+      validation: proposalInput.validation,
+      verifier: "agent:proposer",
+    })),
+    "the proposer cannot verify its own proposal",
+  ),
+  result(
+    "whitespace_cannot_bypass_self_verification",
+    rejected(() => verifyProposal({
+      evidence: proposalInput.evidence,
+      proposal,
+      validation: proposalInput.validation,
+      verifier: " agent:proposer ",
+    })),
+    "actor identity is canonicalized before the independence comparison",
+  ),
+  result(
+    "forged_proposal_bytes_are_rejected",
+    rejected(() => promoteProposal({ governance_decision: decision, proposal: forgedProposal, verification })),
+    "changing proposal bytes without minting a matching VersionID is rejected",
+  ),
+  result(
+    "forged_verification_bytes_are_rejected",
+    rejected(() => promoteProposal({ governance_decision: decision, proposal, verification: forgedVerification })),
+    "changing verification bytes without minting a matching VersionID is rejected",
+  ),
+  result(
+    "stale_verification_is_rejected",
+    rejected(() => promoteProposal({ governance_decision: decision, proposal: proposalV2, verification })),
+    "verification and governance for an older proposal version cannot promote a newer proposal",
+  ),
+  result(
+    "wrong_kind_verification_is_rejected",
+    rejected(() => promoteProposal({ governance_decision: decision, proposal, verification: wrongKindVerification })),
+    "a content-valid record with the wrong semantic kind cannot stand in for verification",
+  ),
+  result(
+    "wrong_governance_link_is_rejected",
+    rejected(() => promoteProposal({ governance_decision: wrongLinkDecision, proposal, verification })),
+    "governance must bind the exact verification StableRef and VersionID",
+  ),
+  result(
+    "wrong_kind_governance_is_rejected",
+    rejected(() => promoteProposal({ governance_decision: wrongKindDecision, proposal, verification })),
+    "a content-valid record with the wrong semantic kind cannot stand in for governance",
+  ),
+  result(
+    "forged_governance_bytes_are_rejected",
+    rejected(() => promoteProposal({ governance_decision: forgedDecision, proposal, verification })),
+    "changing governance bytes without minting a matching VersionID is rejected",
+  ),
+  result(
+    "nested_evidence_bytes_are_rejected",
+    rejected(() => promoteProposal({ governance_decision: decision, proposal, verification: verificationWithTamperedEvidence })),
+    "an outer-valid verification cannot hide evidence whose bytes no longer match its VersionID",
+  ),
+  result(
+    "unbound_identity_alias_is_rejected",
+    rejected(() => promoteProposal({ governance_decision: aliasInjectedDecision, proposal, verification })),
+    "canonical learning records reject alternate identity fields that are not part of their VersionID",
+  ),
+  result(
+    "verification_actor_cannot_govern_same_proposal",
+    rejected(() => decideProposal({
+      decision: "ACCEPT",
+      governance_decision: { actor: "agent:verifier" },
+      proposal,
+      verification,
+    })),
+    "independent verification and governance remain separate actors",
+  ),
+];
+
+const report = {
+  contract: "agent-native-governed-learning-integrity",
+  ok: rows.every((row) => row.ok),
+  results: rows,
+};
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/test-agent-mcp.mjs
+++ b/scripts/test-agent-mcp.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+/**
+ * MCP adapter contract harness.
+ *
+ * This is deliberately an in-memory test: it exercises the official stable
+ * MCP SDK's initialize/list/read/call path without making stdio, network, or
+ * filesystem state part of the proof.  The StyleGallery adapter remains the
+ * only domain implementation under test.
+ */
+
+function parseTextContent(response) {
+  const text = response?.content?.find((item) => item?.type === "text")?.text;
+  if (typeof text !== "string") return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function responseEnvelope(response) {
+  if (response?.structuredContent && typeof response.structuredContent === "object") {
+    return response.structuredContent;
+  }
+  return parseTextContent(response);
+}
+
+function result(name, expected, actual, ok) {
+  return { actual, expected, name, ok };
+}
+
+function denialObserved(error, response) {
+  if (error) {
+    const code = error?.code ?? error?.data?.code;
+    const message = String(error?.message ?? error);
+    return {
+      code,
+      message,
+      observed: ["-32601", "-32602", "method_not_found", "operation_not_exposed", "read_only_denied"]
+        .some((item) => String(code) === item || message.toLowerCase().includes(item.replaceAll("_", " ")))
+        || /unknown|not found|not exposed|read.?only|proposal/i.test(message),
+    };
+  }
+  const envelope = responseEnvelope(response);
+  const codes = Array.isArray(envelope?.failures)
+    ? envelope.failures.map((item) => item?.code).filter((item) => typeof item === "string")
+    : [];
+  const message = typeof envelope === "string"
+    ? envelope
+    : String(response?.content?.find((item) => item?.type === "text")?.text ?? "");
+  const protocolCode = message.match(/-326\d+/)?.[0] ?? null;
+  const codeDenied = codes.some((code) => /denied|not.?exposed|not.?found|read.?only|unknown/i.test(code));
+  const messageDenied = /unknown|not found|not exposed|read.?only|proposal|(-32601)|(-32602)/i.test(message);
+  return {
+    code: codes[0] ?? protocolCode,
+    message,
+    isError: response?.isError === true,
+    observed: response?.isError === true && (codeDenied || messageDenied),
+  };
+}
+
+async function importDependencies(results) {
+  let sdk;
+  try {
+    sdk = {
+      ...(await import("@modelcontextprotocol/sdk/server/mcp.js")),
+      ...(await import("@modelcontextprotocol/sdk/client/index.js")),
+      ...(await import("@modelcontextprotocol/sdk/inMemory.js")),
+    };
+  } catch (error) {
+    results.push(result(
+      "stable_sdk_available",
+      "official @modelcontextprotocol/sdk v1 can be imported",
+      { code: "mcp_sdk_unavailable", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+    return null;
+  }
+  results.push(result(
+    "stable_sdk_available",
+    "official McpServer, Client, and InMemoryTransport exports are available",
+    { exports: ["McpServer", "Client", "InMemoryTransport"].filter((name) => typeof sdk[name] === "function") },
+    typeof sdk.McpServer === "function" && typeof sdk.Client === "function" && typeof sdk.InMemoryTransport?.createLinkedPair === "function",
+  ));
+  if (typeof sdk.McpServer !== "function" || typeof sdk.Client !== "function" || typeof sdk.InMemoryTransport?.createLinkedPair !== "function") return null;
+  return sdk;
+}
+
+async function importAdapter(results) {
+  try {
+    const adapter = await import("./agent-native/mcp-adapter.mjs");
+    const factory = adapter.createStyleGalleryMcpServer ?? adapter.createMcpServer;
+    results.push(result(
+      "adapter_factory_available",
+      "mcp-adapter exports createStyleGalleryMcpServer",
+      { exports: Object.keys(adapter).sort() },
+      typeof factory === "function",
+    ));
+    return factory;
+  } catch (error) {
+    results.push(result(
+      "adapter_factory_available",
+      "mcp-adapter exports createStyleGalleryMcpServer",
+      { code: "mcp_adapter_unavailable", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+    return null;
+  }
+}
+
+async function main() {
+  const results = [];
+  const sdk = await importDependencies(results);
+  const createServer = await importAdapter(results);
+  if (!sdk || !createServer) {
+    const report = { ok: false, results };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const server = await createServer();
+  const [clientTransport, serverTransport] = sdk.InMemoryTransport.createLinkedPair();
+  const client = new sdk.Client({ name: "stylegallery-mcp-conformance", version: "1.0.0" });
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const capabilities = client.getServerCapabilities?.() ?? {};
+    results.push(result(
+      "initialize_capability_negotiation",
+      "initialized client/server expose resources and tools",
+      { capabilities },
+      Boolean(capabilities && typeof capabilities === "object"
+        && capabilities.resources && capabilities.tools),
+    ));
+
+    const listedTools = await client.listTools();
+    const toolNames = (listedTools?.tools ?? []).map((item) => item?.name).filter((item) => typeof item === "string").sort();
+    const expectedTools = ["claims", "context", "discover", "ops", "resolve", "retrieve"];
+    results.push(result(
+      "read_only_tool_allowlist",
+      "exactly the six public read operations are advertised",
+      { toolNames, expectedTools },
+      expectedTools.every((name) => toolNames.includes(name))
+        && toolNames.length === expectedTools.length
+        && !toolNames.some((name) => /proposal|promote|decide|reconcile|write|delete|execute/i.test(name)),
+    ));
+
+    const listedResources = await client.listResources();
+    const resourceUris = (listedResources?.resources ?? []).map((item) => item?.uri).filter((item) => typeof item === "string").sort();
+    const expectedResources = ["sg://manifest", "sg://self"];
+    results.push(result(
+      "read_only_resource_catalog",
+      "sg://self and sg://manifest are advertised as immutable resources",
+      { resourceUris, expectedResources },
+      expectedResources.every((uri) => resourceUris.includes(uri)),
+    ));
+
+    for (const uri of expectedResources) {
+      let response;
+      try {
+        response = await client.readResource({ uri });
+        const contents = response?.contents ?? [];
+        const text = contents.find((item) => item?.uri === uri)?.text;
+        let parsed = null;
+        try { parsed = JSON.parse(text); } catch { /* structured resource text is checked below */ }
+        results.push(result(
+          `read_resource_${uri.slice("sg://".length)}`,
+          "one JSON resource content with the requested immutable URI",
+          { contents: contents.length, parsedType: parsed === null ? typeof text : typeof parsed, response },
+          contents.length > 0 && typeof text === "string" && text.length > 0 && parsed !== null && typeof parsed === "object",
+        ));
+      } catch (error) {
+        results.push(result(
+          `read_resource_${uri.slice("sg://".length)}`,
+          "resource/read succeeds over the official SDK",
+          { code: "resource_read_failed", error: error instanceof Error ? error.message : String(error) },
+          false,
+        ));
+      }
+    }
+
+    for (const name of ["discover", "ops"]) {
+      try {
+        const response = await client.callTool({ name, arguments: {} });
+        const envelope = responseEnvelope(response);
+        results.push(result(
+          `call_read_tool_${name}`,
+          "tools/call returns a successful structured domain envelope",
+          { response, envelope },
+          response?.isError !== true && envelope?.ok === true && envelope?.operation === name && envelope?.result && typeof envelope.result === "object",
+        ));
+      } catch (error) {
+        results.push(result(
+          `call_read_tool_${name}`,
+          "tools/call returns a successful structured domain envelope",
+          { code: "tool_call_failed", error: error instanceof Error ? error.message : String(error) },
+          false,
+        ));
+      }
+    }
+
+    let denial;
+    try {
+      const response = await client.callTool({ name: "proposal.create", arguments: {} });
+      denial = denialObserved(null, response);
+    } catch (error) {
+      denial = denialObserved(error, null);
+    }
+    results.push(result(
+      "mutating_tool_denied",
+      "a mutating operation is not exposed and is denied by the read-only MCP surface",
+      denial,
+      denial.observed === true,
+    ));
+  } catch (error) {
+    results.push(result(
+      "sdk_round_trip",
+      "MCP initialize/list/read/call completes without transport failure",
+      { code: "mcp_round_trip_failed", error: error instanceof Error ? error.message : String(error) },
+      false,
+    ));
+  } finally {
+    await client.close().catch(() => {});
+    const closed = server.close?.();
+    if (closed && typeof closed.catch === "function") await closed.catch(() => {});
+  }
+
+  const report = { ok: results.every((item) => item.ok), results };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+await main().catch((error) => {
+  const report = {
+    ok: false,
+    results: [result(
+      "mcp_harness_runtime",
+      "harness emits structured JSON instead of crashing",
+      { code: "mcp_harness_runtime", error: error instanceof Error ? error.message : String(error) },
+      false,
+    )],
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-agent-native-schemas.mjs
+++ b/scripts/test-agent-native-schemas.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+import { agentNativeFixture } from "./agent-native/fixture.mjs";
+import {
+  authorizeOperation,
+  createReceipt,
+  createTask,
+  defineOperation,
+  recordEffectAttempt,
+  startRun,
+} from "./agent-native/execution.mjs";
+import { appendEvent } from "./agent-native/events.mjs";
+import {
+  createClaim,
+  createEvidenceLink,
+  createGovernanceDecision,
+  createValidationReport,
+} from "./agent-native/knowledge.mjs";
+import {
+  createProposal,
+  decideProposal,
+  promoteProposal,
+  verifyProposal,
+} from "./agent-native/learning.mjs";
+import { buildContextPackage, buildViewSnapshot } from "./agent-native/retrieval.mjs";
+import { createAgentCard } from "./agent-native/a2a-projection.mjs";
+import { projectAgUiEvents } from "./agent-native/agui-projection.mjs";
+import { agentNativeRegistry } from "./agent-native/registry.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaDirectory = path.join(root, "consumer-reference", "agent-native", "schema");
+const rootSchema = JSON.parse(fs.readFileSync(path.join(schemaDirectory, "agent-native.schema.json"), "utf8"));
+const ajv = new Ajv2020({ allErrors: true, strict: true, strictRequired: false });
+addFormats(ajv);
+ajv.addSchema(rootSchema);
+
+const wrapperNames = ["identity", "manifest", "epistemic", "operation", "execution", "protocol-binding", "retrieval", "learning"];
+for (const name of wrapperNames) {
+  const schema = JSON.parse(fs.readFileSync(path.join(schemaDirectory, `${name}.schema.json`), "utf8"));
+  ajv.addSchema(schema);
+}
+
+const rows = [];
+function validator(name) {
+  const fn = ajv.getSchema(`${rootSchema.$id}#/$defs/${name}`);
+  assert.equal(typeof fn, "function", `missing validator for ${name}`);
+  return fn;
+}
+
+function valid(name, schemaName, value) {
+  const fn = validator(schemaName);
+  const ok = fn(value);
+  rows.push({ name, schema: schemaName, ok, errors: ok ? [] : fn.errors });
+  assert.equal(ok, true, `${name} did not satisfy ${schemaName}: ${JSON.stringify(fn.errors)}`);
+}
+
+function invalid(name, schemaName, value) {
+  const fn = validator(schemaName);
+  const ok = fn(value);
+  rows.push({ name, schema: schemaName, ok: !ok, errors: ok ? [] : fn.errors });
+  assert.equal(ok, false, `${name} unexpectedly satisfied ${schemaName}`);
+}
+
+function fixtureSchema(recordKind) {
+  return {
+    artifact_projection: "artifactProjection",
+    executable_fixture: "executableFixture",
+    profile_projection: "profileProjection",
+    agent_description: "agentDescription",
+    validator: "validator",
+    execution_receipt: "executionReceipt",
+    conformance_profile: "conformanceProfile",
+    claim: "claim",
+    evidence_link: "evidenceLink",
+    validation_report: "validationReport",
+    governance_decision: "governanceDecision",
+    policy_disposition: "policyDisposition",
+    operation: "operationSpec",
+  }[recordKind];
+}
+
+function buildSamples() {
+  const claim = createClaim({
+    actor: "sg:agent/schema-fixture",
+    stable_ref: "sg:claim/schema-fixture",
+    statement: "Closed schemas reject undeclared fields.",
+    subject_ref: "sg:profile/editorial-reference-profile",
+  });
+  const evidence = createEvidenceLink({
+    claim_ref: claim.stable_ref,
+    claim_version: claim.version_id,
+    independence_group: "schema-fixture",
+    polarity: "SUPPORT",
+    source_ref: "sg:artifact/schema-fixture",
+    stable_ref: "sg:evidence/schema-fixture",
+  });
+  const validation = createValidationReport({
+    claim_ref: claim.stable_ref,
+    claim_version: claim.version_id,
+    stable_ref: "sg:validation/schema-fixture",
+    status: "PASS",
+    suite: "schema-fixture",
+    validator_ref: "sg:validator/schema-fixture",
+    validator_version: "schema-validator@1",
+  });
+  const governance = createGovernanceDecision({
+    actor: "sg:governor/schema-fixture",
+    claim_ref: claim.stable_ref,
+    claim_version: claim.version_id,
+    decision: "ACCEPT",
+    policy_version: "schema-policy@1",
+    stable_ref: "sg:governance/schema-fixture",
+  });
+  const operation = defineOperation({
+    adapters: ["cli", "mcp"],
+    description: "Schema fixture operation.",
+    effect_class: "NONE",
+    input_schema: { additionalProperties: false, type: "object" },
+    name: "schema-fixture",
+    output_schema: { type: "object" },
+    required_capability: null,
+    stable_ref: "sg:operation/schema-fixture",
+  });
+  const grant = {
+    capability: "wiki.read",
+    operations: ["schema-fixture"],
+    resource_scope: ["sg:profile/*"],
+    subject: "agent:schema-fixture",
+  };
+  const authorization = authorizeOperation({
+    grant,
+    now: "2099-01-01T00:00:00.000Z",
+    operation,
+    resource: "sg:profile/editorial-reference-profile",
+    subject: "agent:schema-fixture",
+  });
+  const task = createTask({ intent: { operation: operation.name }, required_result: {}, stable_ref: "sg:task/schema-fixture" });
+  const run = startRun({ input: {}, run_id: "sg:run/schema-fixture", task });
+  const effect = recordEffectAttempt({ effect_class: "LOCAL", effect_id: "sg:effect/schema-fixture", run, task });
+  const receipt = createReceipt({ effects: [effect], input: {}, operation, output: {}, run, task, policy_decision: authorization.decision });
+  const event = appendEvent({ event: { event_id: "sg:event/schema-fixture", parents: [], payload: { task_id: task.task_id }, type: "task.created" }, events: [] })[0];
+  const snapshot = buildViewSnapshot({ heads: [event.event_id], members: [claim], snapshot_ref: "sg:view/schema-fixture", view_spec: { query: "schema" } });
+  const context = buildContextPackage({ budget: { tokens: 128 }, members: [claim], query: "schema", snapshot });
+  const proposal = createProposal({
+    changes: [{ path: "claim.statement", value: "A governed change." }],
+    claim: { stable_ref: claim.stable_ref, statement: claim.statement },
+    evidence: [evidence],
+    proposer: "agent:proposer",
+    stable_ref: "sg:proposal/schema-fixture",
+    validation: { status: "PASS", validator: "agent:validator" },
+  });
+  const proposalEvidence = proposal.evidence.map(({ version_id: _version_id, ...item }) => item);
+  const proposalValidation = (({ version_id: _version_id, ...item }) => item)(proposal.validation);
+  const verification = verifyProposal({ evidence: proposalEvidence, proposal, validation: proposalValidation, verifier: "agent:verifier" });
+  const decision = decideProposal({ decision: "ACCEPT", governance_decision: { actor: "agent:governor", decision: "ACCEPT" }, proposal, verification });
+  const promotion = promoteProposal({ decision, proposal, verification });
+  return { claim, evidence, validation, governance, operation, grant, authorization, task, run, effect, receipt, event, snapshot, context, proposal, verification, decision, promotion, card: createAgentCard(), agui: projectAgUiEvents({ task, run, text: "schema", toolCall: { id: "schema-tool", name: operation.name }, state: snapshot }) };
+}
+
+function run() {
+  valid("fixture manifest is closed", "manifest", agentNativeFixture.manifest);
+  for (const record of agentNativeFixture.records) {
+    const schemaName = fixtureSchema(record.record_kind);
+    assert.ok(schemaName, `fixture record kind ${record.record_kind} has no closed schema`);
+    valid(`fixture ${record.stable_ref}`, schemaName, record);
+  }
+  const sample = buildSamples();
+  const wrapperSamples = {
+    identity: sample.claim.stable_ref,
+    manifest: agentNativeFixture.manifest,
+    epistemic: sample.claim,
+    operation: sample.operation,
+    execution: sample.task,
+    "protocol-binding": { protocol: "a2a", protocolBindingId: "sg:binding/schema-fixture" },
+    retrieval: sample.snapshot,
+    learning: sample.proposal,
+  };
+  for (const name of wrapperNames) {
+    const fn = ajv.getSchema(`https://stylegallery.local/consumer-reference/agent-native/schema/${name}.schema.json`);
+    assert.equal(typeof fn, "function", `missing wrapper validator ${name}`);
+    const ok = fn(wrapperSamples[name]);
+    rows.push({ name: `wrapper ${name}`, schema: `${name}.schema.json`, ok, errors: ok ? [] : fn.errors });
+    assert.equal(ok, true, `wrapper ${name} rejected its representative value: ${JSON.stringify(fn.errors)}`);
+  }
+  for (const [name, schemaName] of Object.entries({ claim: "claim", evidence: "evidenceLink", validation: "validationReport", governance: "governanceDecision", operation: "operationSpec", grant: "capabilityGrant", authorization: "authorizationResult", task: "task", run: "run", effect: "effect", receipt: "invocationReceipt", event: "event", snapshot: "viewSnapshot", context: "contextPackage", proposal: "learningProposal", verification: "learningVerification", decision: "governanceDecision", promotionVersion: "governedVersion", promotionReceipt: "promotionReceipt", card: "agentCard", agui: "aguiProjection" })) valid(`generated ${name}`, schemaName, name === "promotionVersion" ? sample.promotion.version : name === "promotionReceipt" ? sample.promotion.receipt : sample[name]);
+  valid("generated A2A binding", "protocolBinding", sample.card ? { protocol: "a2a", protocolBindingId: "sg:binding/schema-fixture" } : {});
+  valid("generated self-description", "selfDescription", agentNativeRegistry.selfDescription);
+  invalid("manifest unknown property is rejected", "manifest", { ...agentNativeFixture.manifest, unexpected: true });
+  invalid("claim unknown property is rejected", "claim", { ...sample.claim, unexpected: true });
+  invalid("malformed StableRef is rejected", "claim", { ...sample.claim, stable_ref: "claim/schema-fixture" });
+  invalid("malformed VersionID is rejected", "claim", { ...sample.claim, version_id: `${sample.claim.stable_ref}@sha256:${"0".repeat(63)}z` });
+  return rows;
+}
+
+if (process.argv.slice(2).some((arg) => arg !== "--json")) {
+  process.stdout.write(`${JSON.stringify({ ok: false, status: "RED", failures: [{ code: "argument_unknown" }], results: [] }, null, 2)}\n`);
+  process.exitCode = 1;
+} else {
+  try {
+    const results = run();
+    const report = { contract: "agent-native-closed-schemas", ok: true, results };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } catch (error) {
+    const report = { contract: "agent-native-closed-schemas", ok: false, results: rows, failure: { message: error instanceof Error ? error.message : String(error) } };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test-agent-projections.mjs
+++ b/scripts/test-agent-projections.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const moduleFiles = Object.freeze({
+  a2a: path.join(repositoryRoot, "scripts", "agent-native", "a2a-projection.mjs"),
+  agui: path.join(repositoryRoot, "scripts", "agent-native", "agui-projection.mjs"),
+});
+
+const domainTask = Object.freeze({
+  stableRef: "sg:task/projection-fixture",
+  taskId: "sg:task/projection-fixture",
+  state: "RUNNING",
+  runId: "sg:run/projection-fixture",
+  intent: { operation: "resolve", stableRef: "sg:profile/editorial-reference-profile" },
+  requiredResult: { type: "profile" },
+});
+const domainRun = Object.freeze({ runId: "sg:run/projection-fixture", taskId: domainTask.taskId, state: "RUNNING" });
+const protocolBinding = Object.freeze({
+  bindingId: "sg:binding/a2a-projection-fixture",
+  protocolBindingId: "sg:binding/a2a-projection-fixture",
+  protocol: "a2a",
+  taskId: domainTask.taskId,
+  runId: domainRun.runId,
+});
+const message = Object.freeze({
+  messageId: "a2a-message-projection-fixture",
+  role: "user",
+  parts: [{ kind: "text", text: "Resolve the editorial profile." }],
+});
+
+function pick(value, ...keys) {
+  if (!value || typeof value !== "object") return undefined;
+  for (const key of keys) if (Object.hasOwn(value, key)) return value[key];
+  return undefined;
+}
+
+function unwrap(value) {
+  return value?.ok === true && Object.hasOwn(value, "result") ? value.result : value;
+}
+
+function object(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stateOf(value) {
+  const status = pick(value, "status");
+  return String(pick(status, "state", "status") ?? pick(value, "state", "taskState", "task_state") ?? "").toLowerCase();
+}
+
+function idOf(value, ...keys) {
+  return pick(value, ...keys, "id", "taskId", "task_id", "runId", "run_id", "stableRef", "stable_ref");
+}
+
+async function load(name) {
+  try {
+    return { ok: true, module: await import(pathToFileURL(moduleFiles[name]).href) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "kernel_module_missing",
+        module: name,
+        path: moduleFiles[name],
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+function findExport(loaded, names, moduleName) {
+  if (!loaded.ok) throw Object.assign(new Error(loaded.error.message), loaded.error);
+  for (const name of names) if (typeof loaded.module[name] === "function") return loaded.module[name];
+  const error = new Error(`${moduleName} must export one of ${names.join(", ")}`);
+  error.code = "kernel_export_missing";
+  error.module = moduleName;
+  throw error;
+}
+
+async function call(loaded, names, moduleName, input) {
+  const fn = findExport(loaded, names, moduleName);
+  return await fn(input);
+}
+
+function row(name, expected, actual, ok, details) {
+  return { actual, expected, name, ok, ...(details ? { details } : {}) };
+}
+
+function failure(error) {
+  return { code: error?.code ?? "projection_case_exception", message: error?.message ?? String(error), ...(error?.path ? { path: error.path } : {}) };
+}
+
+function taskProjection(value) {
+  const result = unwrap(value);
+  return pick(result, "task", "taskProjection", "task_projection") ?? result;
+}
+
+function bindingOf(value) {
+  const result = unwrap(value);
+  return pick(result, "protocolBinding", "protocol_binding", "binding") ?? {};
+}
+
+function protocolTaskId(value) {
+  const task = taskProjection(value);
+  return idOf(task, "id", "taskId", "task_id");
+}
+
+async function testA2A(loaded) {
+  const rows = [];
+  try {
+    const card = unwrap(await call(loaded, ["createAgentCard", "buildAgentCard", "projectAgentCard", "agentCard"], "a2a", { fixture: true }));
+    const capabilities = pick(card, "capabilities");
+    rows.push(row(
+      "a2a_agent_card_is_v1_shaped",
+      "Agent Card has protocolVersion, identity, URL, capabilities, input/output modes, and skills",
+      card,
+      object(card)
+        && typeof pick(card, "protocolVersion", "protocol_version") === "string"
+        && typeof pick(card, "name") === "string"
+        && typeof pick(card, "url") === "string"
+        && object(capabilities)
+        && Array.isArray(pick(card, "defaultInputModes", "default_input_modes"))
+        && Array.isArray(pick(card, "defaultOutputModes", "default_output_modes"))
+        && Array.isArray(pick(card, "skills")),
+    ));
+
+    const map = findExport(loaded, ["mapTaskState", "projectTaskState", "toA2ATaskState"], "a2a");
+    const mappings = {
+      PENDING: "submitted", RUNNING: "working", COMPLETED: "completed", FAILED: "failed",
+      CANCELED: "canceled", REJECTED: "rejected", AUTH_REQUIRED: "auth-required", UNKNOWN: "unknown",
+    };
+    const actualMappings = Object.fromEntries(Object.entries(mappings).map(([input]) => [input, map(input)]));
+    rows.push(row("a2a_task_state_mapping_is_total", "all domain terminal/intermediate states map to official A2A states", actualMappings, Object.entries(mappings).every(([input, expected]) => String(actualMappings[input]).toLowerCase() === expected)));
+
+    const send = unwrap(await call(loaded, ["sendMessage", "projectSendMessage", "handleSendMessage"], "a2a", {
+      message,
+      task: domainTask,
+      run: domainRun,
+      protocolBinding,
+    }));
+    const sentTaskId = protocolTaskId(send);
+    const sentBinding = bindingOf(send);
+    const bindingId = idOf(sentBinding, "protocolBindingId", "protocol_binding_id", "bindingId", "binding_id");
+    const boundTaskId = idOf(sentBinding, "taskId", "task_id", "domainTaskId", "domain_task_id");
+    const boundRunId = idOf(sentBinding, "runId", "run_id", "domainRunId", "domain_run_id");
+    rows.push(row(
+      "a2a_send_message_creates_distinct_protocol_binding",
+      "SendMessage returns a submitted A2A task and ProtocolBinding that does not replace domain Task/Run IDs",
+      { taskId: sentTaskId, state: stateOf(send), bindingId, boundTaskId, boundRunId },
+      object(send) && typeof sentTaskId === "string" && stateOf(send) === "submitted"
+        && typeof bindingId === "string" && bindingId !== domainTask.taskId && bindingId !== domainRun.runId
+        && boundTaskId === domainTask.taskId && boundRunId === domainRun.runId,
+    ));
+
+    const get = unwrap(await call(loaded, ["getTask", "projectGetTask", "handleGetTask"], "a2a", {
+      task: send,
+      domainTask,
+      run: domainRun,
+      protocolBinding: sentBinding,
+      taskId: sentTaskId,
+    }));
+    rows.push(row("a2a_get_task_projects_current_domain_state", "GetTask preserves protocol task identity and maps RUNNING to working", { taskId: protocolTaskId(get), state: stateOf(get) }, protocolTaskId(get) === sentTaskId && stateOf(get) === "working"));
+
+    const canceled = unwrap(await call(loaded, ["cancelTask", "projectCancelTask", "handleCancelTask"], "a2a", {
+      task: get,
+      domainTask: { ...domainTask, state: "CANCELED" },
+      run: domainRun,
+      protocolBinding: sentBinding,
+      taskId: sentTaskId,
+    }));
+    rows.push(row("a2a_cancel_task_projects_canceled", "CancelTask returns the same protocol task in canceled state", { taskId: protocolTaskId(canceled), state: stateOf(canceled) }, protocolTaskId(canceled) === sentTaskId && stateOf(canceled) === "canceled"));
+  } catch (error) {
+    rows.push(row("a2a_projection_kernel_available", "A2A projection module exports the required pure functions", failure(error), false));
+  }
+  return rows;
+}
+
+function eventType(event) {
+  return String(pick(event, "type", "eventType", "event_type", "name") ?? "").toUpperCase();
+}
+
+function eventList(value) {
+  const result = unwrap(value);
+  return Array.isArray(result) ? result : pick(result, "events", "items") ?? [];
+}
+
+async function testAGUI(loaded) {
+  const rows = [];
+  try {
+    const project = findExport(loaded, ["projectAgUiEvents", "projectAGUIEvents", "projectAguiEvents", "createAgUiEvents"], "agui");
+    const projection = await project({
+      task: domainTask,
+      run: domainRun,
+      protocolBinding: { ...protocolBinding, protocol: "ag-ui", bindingId: "sg:binding/agui-projection-fixture" },
+      text: "Editorial profile resolved.",
+      toolCall: { id: "tool-call-projection-fixture", name: "resolve", args: { stableRef: "sg:profile/editorial-reference-profile" } },
+      state: { stableRef: "sg:profile/editorial-reference-profile", status: "resolved" },
+      outcome: "COMPLETED",
+    });
+    const events = eventList(projection);
+    const types = events.map(eventType);
+    const index = (names) => types.findIndex((type) => names.includes(type));
+    const terminal = types.filter((type) => ["RUN_FINISHED", "RUN_ERROR"].includes(type));
+    const ordered = index(["RUN_STARTED"]) >= 0
+      && index(["TEXT_MESSAGE_START"]) > index(["RUN_STARTED"])
+      && index(["TEXT_MESSAGE_CONTENT"]) > index(["TEXT_MESSAGE_START"])
+      && index(["TEXT_MESSAGE_END"]) > index(["TEXT_MESSAGE_CONTENT"])
+      && index(["TOOL_CALL_START"]) > index(["TEXT_MESSAGE_END"])
+      && index(["TOOL_CALL_ARGS", "TOOL_CALL_ARGUMENTS"]) > index(["TOOL_CALL_START"])
+      && index(["TOOL_CALL_END"]) > index(["TOOL_CALL_ARGS", "TOOL_CALL_ARGUMENTS"])
+      && index(["STATE_SNAPSHOT", "STATE_DELTA"]) > index(["TOOL_CALL_END"])
+      && terminal.length === 1
+      && types.indexOf(terminal[0]) === types.length - 1;
+    rows.push(row("agui_projection_has_ordered_v057_lifecycle", "RUN, text, tool, state, then exactly one terminal event", { types }, ordered));
+
+    const validate = findExport(loaded, ["validateAgUiTransitions", "validateAGUITransitions", "assertAgUiTransitions", "validateEventSequence"], "agui");
+    let rejected = false;
+    let rejection;
+    try {
+      rejection = await validate({ events: [{ type: "RUN_FINISHED", runId: "protocol-run-fixture" }, { type: "RUN_STARTED", runId: "protocol-run-fixture" }] });
+      rejected = rejection?.ok === false || rejection?.valid === false;
+    } catch (error) {
+      rejected = true;
+      rejection = failure(error);
+    }
+    rows.push(row("agui_invalid_transition_is_rejected", "a terminal-before-start sequence is rejected before projection", rejection, rejected));
+  } catch (error) {
+    rows.push(row("agui_projection_kernel_available", "AG-UI projection module exports ordered event and transition validation functions", failure(error), false));
+  }
+  return rows;
+}
+
+async function main() {
+  const unsupported = process.argv.slice(2).filter((argument) => argument !== "--json");
+  if (unsupported.length > 0) {
+    process.stdout.write(`${JSON.stringify({ ok: false, status: "RED", failures: [{ code: "argument_unknown", message: `unknown argument ${unsupported[0]}` }], results: [] }, null, 2)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const modules = { a2a: await load("a2a"), agui: await load("agui") };
+  const results = [...await testA2A(modules.a2a), ...await testAGUI(modules.agui)];
+  const ok = results.every((result) => result.ok);
+  process.stdout.write(`${JSON.stringify({ ok, status: ok ? "GREEN" : "RED", modules: Object.fromEntries(Object.entries(modules).map(([name, loaded]) => [name, loaded.ok ? { ok: true } : { ok: false, error: loaded.error }])), results }, null, 2)}\n`);
+  process.exitCode = ok ? 0 : 1;
+}
+
+await main();

--- a/scripts/test-agent-registry-mcp-integrity.mjs
+++ b/scripts/test-agent-registry-mcp-integrity.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { canonicalize } from "./agent-native/canonical-json.mjs";
+import { createStyleGalleryMcpServer } from "./agent-native/mcp-adapter.mjs";
+import { agentNativeRegistry } from "./agent-native/registry.mjs";
+
+const MUTATIONS = [
+  "effect.record",
+  "effect.reconcile",
+  "proposal.create",
+  "proposal.decide",
+  "proposal.promote",
+  "proposal.verify",
+  "run.start",
+  "task.create",
+];
+const PROFILE_REF = "sg:profile/editorial-reference-profile";
+
+function result(name, expected, actual, ok) {
+  return { actual, expected, name, ok };
+}
+
+function equal(left, right) {
+  return canonicalize(left) === canonicalize(right);
+}
+
+function envelope(response) {
+  if (response?.structuredContent && typeof response.structuredContent === "object") return response.structuredContent;
+  const text = response?.content?.find((item) => item?.type === "text")?.text;
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+async function connected(registry = agentNativeRegistry) {
+  const server = createStyleGalleryMcpServer({ registry });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "stylegallery-registry-mcp-integrity", version: "1.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+async function close(connection) {
+  await connection.client.close().catch(() => {});
+  const closed = connection.server.close?.();
+  if (closed && typeof closed.catch === "function") await closed.catch(() => {});
+}
+
+async function rejected(action) {
+  try {
+    const response = await action();
+    return { error: null, response };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error), response: null };
+  }
+}
+
+async function main() {
+  const results = [];
+  const names = agentNativeRegistry.operations.map((operation) => operation.name).sort();
+  const missingMutations = MUTATIONS.filter((name) => !names.includes(name));
+  results.push(result(
+    "common_registry_contains_governed_mutations",
+    "proposal, task, run, effect recording, and effect reconciliation operations exist in the common registry",
+    { missingMutations, names },
+    missingMutations.length === 0,
+  ));
+
+  const invalidMetadata = agentNativeRegistry.operations
+    .filter((operation) => typeof operation.read_only !== "boolean"
+      || (operation.read_only === true && operation.effect_class !== "NONE"))
+    .map((operation) => ({ effect_class: operation.effect_class, name: operation.name, read_only: operation.read_only }));
+  const registryReads = agentNativeRegistry.operations.filter((operation) => operation.read_only === true).map((operation) => operation.name).sort();
+  results.push(result(
+    "registry_read_only_metadata_is_closed",
+    "every operation declares read_only and no effectful operation is read-only",
+    { invalidMetadata, registryReads },
+    invalidMetadata.length === 0 && registryReads.length > 0,
+  ));
+
+  for (const name of MUTATIONS.filter((item) => names.includes(item))) {
+    const invoked = agentNativeRegistry.invoke(name, {});
+    const codes = (invoked.failures ?? []).map((failure) => failure.code);
+    results.push(result(
+      `registered_handler_${name}`,
+      "the registered mutation reaches its schema or handler instead of operation_unknown",
+      invoked,
+      invoked.operation === name && !codes.includes("operation_unknown"),
+    ));
+  }
+
+  const connection = await connected();
+  try {
+    const tools = (await connection.client.listTools()).tools.map((tool) => tool.name).sort();
+    results.push(result(
+      "mcp_tools_derive_from_registry_read_only",
+      registryReads,
+      tools,
+      equal(tools, registryReads),
+    ));
+
+    const mutationCalls = [];
+    for (const name of MUTATIONS) {
+      const observed = await rejected(() => connection.client.callTool({ name, arguments: {} }));
+      const body = envelope(observed.response);
+      mutationCalls.push({ error: observed.error, isError: observed.response?.isError, name, body });
+    }
+    results.push(result(
+      "existing_mutations_are_not_mcp_tools",
+      "every mutation that exists in the registry is absent from MCP and denied on direct call",
+      mutationCalls,
+      mutationCalls.every((call) => !tools.includes(call.name)
+        && (call.error !== null || (call.isError === true && call.body?.failures?.[0]?.code === "operation_not_exposed"))),
+    ));
+
+    const templates = (await connection.client.listResourceTemplates()).resourceTemplates ?? [];
+    const template = templates.find((item) => item.uriTemplate === "sg://object/{reference}");
+    results.push(result(
+      "object_resource_template_is_discoverable",
+      "sg://object/{reference} is advertised",
+      templates,
+      Boolean(template),
+    ));
+
+    const objectUri = `sg://object/${encodeURIComponent(PROFILE_REF)}`;
+    const resources = (await connection.client.listResources()).resources ?? [];
+    const listed = resources.some((resource) => resource.uri === objectUri);
+    const resource = await rejected(() => connection.client.readResource({ uri: objectUri }));
+    const text = resource.response?.contents?.find((item) => item.uri === objectUri)?.text;
+    let parsed = null;
+    try { parsed = JSON.parse(text); } catch { /* asserted below */ }
+    const resolved = agentNativeRegistry.invoke("resolve", { reference: PROFILE_REF });
+    results.push(result(
+      "object_resource_uses_registry_resolver",
+      "the listed encoded object URI returns the exact registry resolve payload",
+      { error: resource.error, listed, parsed, resolved },
+      listed && resource.error === null && resolved.ok === true && equal(parsed, resolved.result),
+    ));
+
+    const unknown = await rejected(() => connection.client.readResource({
+      uri: `sg://object/${encodeURIComponent("sg:profile/does-not-exist")}`,
+    }));
+    const malformed = await rejected(() => connection.client.readResource({ uri: "sg://object/%E0%A4%A" }));
+    const versionId = resolved.ok ? resolved.result.version_id : "";
+    const versioned = await rejected(() => connection.client.readResource({
+      uri: `sg://object/${encodeURIComponent(versionId)}`,
+    }));
+    results.push(result(
+      "object_resource_accepts_only_encoded_stable_refs",
+      "unknown, malformed, and VersionID object references are rejected",
+      { malformed, unknown, versioned },
+      unknown.error !== null && malformed.error !== null && versioned.error !== null,
+    ));
+  } finally {
+    await close(connection);
+  }
+
+  const dynamicName = "diagnostics.snapshot";
+  const dynamicOperation = Object.freeze({
+    adapters: [], description: "Dynamically registered read projection.", effect_class: "NONE",
+    idempotent: true, input_schema: { additionalProperties: false, type: "object" },
+    name: dynamicName, output_schema: { type: "object" }, read_only: true,
+    record_kind: "operation", stable_ref: "sg:operation/diagnostics-snapshot",
+  });
+  const dynamicRegistry = Object.freeze({
+    ...agentNativeRegistry,
+    invoke: (name, input = {}) => name === dynamicName
+      ? Object.freeze({ ok: true, operation: name, result: Object.freeze({ input, source: "dynamic-registry" }) })
+      : agentNativeRegistry.invoke(name, input),
+    operations: Object.freeze([...agentNativeRegistry.operations, dynamicOperation]),
+  });
+  const dynamic = await connected(dynamicRegistry);
+  try {
+    const namesFromMcp = (await dynamic.client.listTools()).tools.map((tool) => tool.name);
+    const called = await dynamic.client.callTool({ name: dynamicName, arguments: {} });
+    results.push(result(
+      "new_read_operation_needs_no_adapter_allowlist_change",
+      "a new read_only registry operation is automatically listed and callable",
+      { called: envelope(called), namesFromMcp },
+      namesFromMcp.includes(dynamicName) && envelope(called)?.ok === true,
+    ));
+  } finally {
+    await close(dynamic);
+  }
+
+  const contradictoryRegistry = {
+    ...agentNativeRegistry,
+    operations: [...agentNativeRegistry.operations, {
+      ...dynamicOperation,
+      effect_class: "EXTERNAL",
+      name: "diagnostics.unsafe",
+      stable_ref: "sg:operation/diagnostics-unsafe",
+    }],
+  };
+  let contradiction;
+  try { createStyleGalleryMcpServer({ registry: contradictoryRegistry }); } catch (error) {
+    contradiction = error instanceof Error ? error.message : String(error);
+  }
+  results.push(result(
+    "contradictory_read_only_effect_metadata_is_rejected",
+    "read_only:true cannot disguise an EXTERNAL operation",
+    { contradiction },
+    typeof contradiction === "string" && contradiction.includes("cannot expose EXTERNAL effects as read-only"),
+  ));
+
+  const report = { ok: results.every((item) => item.ok), results };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+await main().catch((error) => {
+  process.stdout.write(`${JSON.stringify({ ok: false, results: [result("registry_mcp_integrity_runtime", "structured report", error instanceof Error ? error.message : String(error), false)] }, null, 2)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-agent-registry-mutations.mjs
+++ b/scripts/test-agent-registry-mutations.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { agentNativeRegistry as registry } from "./agent-native/registry.mjs";
+
+function result(name, expected, actual, ok) {
+  return { actual, expected, name, ok };
+}
+
+function invoke(name, input) {
+  const response = registry.invoke(name, input);
+  return { name, response };
+}
+
+const claim = registry.fixture.records.find((record) => record.stable_ref === "sg:claim/editorial-profile-addressable");
+const proposal = invoke("proposal.create", {
+  changes: [{ op: "replace", path: "/rank", value: 1 }],
+  claim,
+  evidence: [{
+    independence_group: "registry-proposal-source",
+    polarity: "SUPPORT",
+    source_ref: "sg:artifact/editorial-profile-source",
+    stable_ref: "sg:evidence/registry-proposal-source",
+  }],
+  proposer: "agent:registry-proposer",
+  stable_ref: "sg:proposal/registry-invocation-fixture",
+  validation: { status: "PASS", validator: "validator:proposal", validator_version: "1" },
+});
+const verification = invoke("proposal.verify", {
+  evidence: [{
+    independence_group: "registry-independent-source",
+    polarity: "SUPPORT",
+    source_ref: "sg:artifact/editorial-profile-source",
+    stable_ref: "sg:evidence/registry-independent-source",
+  }],
+  proposal: proposal.response.result,
+  validation: { status: "PASS", validator: "validator:independent", validator_version: "1" },
+  verifier: "agent:registry-verifier",
+});
+const decision = invoke("proposal.decide", {
+  governance_decision: {
+    actor: "governor:stylegallery",
+    decided_at: "2026-07-23T00:00:00.000Z",
+    decision: "ACCEPT",
+  },
+  proposal: proposal.response.result,
+  verification: verification.response.result,
+});
+const promotion = invoke("proposal.promote", {
+  governance_decision: decision.response.result,
+  proposal: proposal.response.result,
+  target_stable_ref: "sg:profile/editorial-reference-profile",
+  verification: verification.response.result,
+});
+
+const task = invoke("task.create", {
+  intent: { operation: "resolve" },
+  required_result: { ok: true },
+  stable_ref: "sg:task/registry-invocation-fixture",
+});
+const run = invoke("run.start", {
+  input: { reference: "sg:profile/editorial-reference-profile" },
+  stable_ref: "sg:run/registry-invocation-fixture",
+  task: task.response.result,
+});
+const effect = invoke("effect.record", {
+  effect_class: "EXTERNAL",
+  run_id: run.response.result?.run_id,
+  stable_ref: "sg:effect/registry-invocation-fixture",
+  task_id: task.response.result?.task_id,
+});
+const reconciliation = invoke("effect.reconcile", {
+  effect: effect.response.result,
+  observations: [{ connector_receipt: "sg:receipt/connector-fixture", status: "COMMITTED" }],
+});
+
+const mutations = [proposal, verification, decision, promotion, task, run, effect, reconciliation];
+const results = [
+  result(
+    "governed_learning_chain_is_invokable_from_common_registry",
+    "PROPOSED -> VERIFIED -> ACCEPT -> PROMOTED",
+    mutations.slice(0, 4).map(({ name, response }) => ({ name, ok: response.ok, status: response.result?.status })),
+    proposal.response.ok && verification.response.ok && decision.response.ok && promotion.response.ok
+      && proposal.response.result.status === "PROPOSED"
+      && verification.response.result.status === "VERIFIED"
+      && decision.response.result.status === "ACCEPT"
+      && promotion.response.result.status === "PROMOTED",
+  ),
+  result(
+    "task_run_effect_reconciliation_is_invokable_from_common_registry",
+    "SUBMITTED -> RUNNING -> UNCERTAIN -> COMMITTED",
+    mutations.slice(4).map(({ name, response }) => ({ name, ok: response.ok, state: response.result?.state })),
+    task.response.ok && run.response.ok && effect.response.ok && reconciliation.response.ok
+      && task.response.result.state === "SUBMITTED"
+      && run.response.result.state === "RUNNING"
+      && effect.response.result.state === "UNCERTAIN"
+      && reconciliation.response.result.state === "COMMITTED",
+  ),
+  result(
+    "invokable_mutations_remain_internal",
+    "all eight invoked operations declare read_only:false and omit MCP adapter exposure",
+    registry.operations.filter((operation) => mutations.some((item) => item.name === operation.name))
+      .map((operation) => ({ adapters: operation.adapters, name: operation.name, read_only: operation.read_only })),
+    registry.operations.filter((operation) => mutations.some((item) => item.name === operation.name))
+      .every((operation) => operation.read_only === false && !operation.adapters.includes("mcp")),
+  ),
+];
+
+const report = { ok: results.every((item) => item.ok), results };
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/scripts/test-sg-cli.mjs
+++ b/scripts/test-sg-cli.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { agentNativeFixture } from "./agent-native/fixture.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cli = path.join(repositoryRoot, "scripts", "sg.mjs");
+const profileRef = "sg:profile/editorial-reference-profile";
+const versionRef = agentNativeFixture.records.find(({ stable_ref }) => stable_ref === profileRef)?.version_id;
+
+const successCases = [
+  { command: "discover", baseArgs: ["discover"] },
+  { command: "resolve", baseArgs: ["resolve", profileRef] },
+  { command: "resolve", baseArgs: ["resolve", versionRef], name: "resolve_version_id" },
+  { command: "claims", baseArgs: ["claims", profileRef] },
+  { command: "context", baseArgs: ["context", profileRef] },
+  { command: "ops", baseArgs: ["ops"] },
+];
+
+const failureCases = [
+  { args: ["--format", "json"], code: "argument_value_required", name: "missing_command" },
+  { args: ["resolve", "--format", "json"], code: "argument_value_required", name: "resolve_missing_stable_ref" },
+  { args: ["claims", "--format", "json"], code: "argument_value_required", name: "claims_missing_stable_ref" },
+  { args: ["resolve", "not-a-stable-ref", "--format", "json"], code: "stable_ref_malformed", name: "malformed_stable_ref" },
+  { args: ["resolve", "sg:profile/unknown-profile", "--format", "json"], code: "stable_ref_unknown", name: "unknown_stable_ref" },
+  { args: ["unknown-command", "--format", "json"], code: "command_unknown", name: "unknown_command" },
+  { args: ["discover", "--unknown", "--format", "json"], code: "argument_unknown", name: "unknown_option" },
+  { args: ["--format", "json", "discover", "--format"], code: "argument_value_required", name: "format_missing_value" },
+  { args: ["--format", "json", "discover", "--format", "yaml"], code: "format_unsupported", name: "unsupported_format" },
+];
+
+function run(args) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  });
+}
+
+function parseJson(child) {
+  if (typeof child.stdout !== "string" || child.stdout.length === 0) return null;
+  try {
+    return JSON.parse(child.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function summarize(child, report) {
+  return {
+    report,
+    signal: child.signal,
+    status: child.status,
+    stderr: child.stderr,
+    stdout: child.stdout,
+  };
+}
+
+function hasSuccessContract(child, report, command) {
+  return child.status === 0
+    && child.signal === null
+    && child.stderr.length === 0
+    && report !== null
+    && report.ok === true
+    && report.operation === command
+    && report.result !== null
+    && typeof report.result === "object";
+}
+
+function formatVariants(baseArgs) {
+  const command = baseArgs[0];
+  const operands = baseArgs.slice(1);
+  return [
+    [...baseArgs, "--format", "json"],
+    ["--format", "json", ...baseArgs],
+    [command, "--format", "json", ...operands],
+  ];
+}
+
+function runSuccessCase(testCase) {
+  const variants = formatVariants(testCase.baseArgs);
+  const runs = variants.map((args) => {
+    const child = run(args);
+    return { args, child, report: parseJson(child) };
+  });
+  const reference = runs[0];
+  const equivalent = runs.every(({ child, report }) => (
+    hasSuccessContract(child, report, testCase.command)
+      && child.stdout === reference.child.stdout
+  ));
+  const repeated = run(testCase.baseArgs.concat(["--format", "json"]));
+  const repeatedReport = parseJson(repeated);
+  const deterministic = hasSuccessContract(repeated, repeatedReport, testCase.command)
+    && repeated.stdout === reference.child.stdout;
+  return {
+    actual: runs.map(({ args, child, report }) => ({ args, ...summarize(child, report) })),
+    expected: "all --format json positions produce one stdout-only success JSON document with identical bytes",
+    name: `${testCase.name ?? testCase.command}_format_order_and_stdout_contract`,
+    ok: equivalent && deterministic,
+  };
+}
+
+function runFailureCase(testCase) {
+  const child = run(testCase.args);
+  const report = parseJson(child);
+  const codes = Array.isArray(report?.failures)
+    ? report.failures.map((failure) => failure?.code)
+    : [];
+  return {
+    actual: { codes, ...summarize(child, report) },
+    expected: `nonzero stdout-only JSON failure containing stable code ${testCase.code}`,
+    name: testCase.name,
+    ok: child.status !== 0
+      && child.signal === null
+      && child.stderr.length === 0
+      && report?.ok === false
+      && codes.length > 0
+      && codes.includes(testCase.code),
+  };
+}
+
+const results = [
+  ...successCases.map(runSuccessCase),
+  ...failureCases.map(runFailureCase),
+];
+const report = { ok: results.every((result) => result.ok), results };
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;


### PR DESCRIPTION
## Summary

- add content-addressed StableRef, VersionID, immutable manifest, epistemic governance, capability, receipt, Task/Run/effect, and reconciliation contracts
- add one 14-operation registry with six read-only operations and eight governed internal reducers
- expose sg discover/resolve/claims/context/ops plus a registry-derived read-only MCP surface and sg://object resources
- add A2A and AG-UI projections, deterministic retrieval, and receipt-backed governed learning
- add closed Draft 2020-12 schemas, executable conformance receipts, adversarial tests, and CI coverage

## Integrity boundaries

- empty capability scopes deny by default
- external effects without durable connector receipts remain UNCERTAIN
- learning promotion rejects forged, stale, wrong-kind, wrong-link, or non-independent records
- MCP derives exposure from read_only registry metadata and never exposes registered mutation operations
- component-state browser evidence was recaptured because package.json and package-lock.json are governed capture sources

## Verification

- npm run test:agent-native
- npm test
- npm run build
- npm run validate
- npm run test:consumer-conformance: 147 passed
- npm run test:component-state
- real Chromium component-state capture: 10 passed, 40 artifacts, 2 profiles
- CLI↔MCP conformance: 8/8
- governed learning integrity: 14/14
- closed schema validation: 65/65
- independent final gate: APPROVE

All commands passed on an isolated clean commit whose product tree was byte-identical to this branch.