### PR TITLE
fix: add missing OKF frontmatter to homepage example README

### DIFF
--- a/examples/stylegallery-homepage/README.md
+++ b/examples/stylegallery-homepage/README.md
@@ -1,3 +1,9 @@
+---
+type: Example Implementation
+title: StyleGallery Homepage Example
+description: Static product-layer homepage built as an end-to-end npm package usage test of the published StyleGallery material corpus.
+---
+
 # StyleGallery Homepage Example
 
 Static product-layer homepage built as an end-to-end npm package usage test.


### PR DESCRIPTION
`scripts/validate-okf.mjs` walks every Markdown file in the repo and treats anything that is not `index.md`/`log.md` as an OKF concept document, requiring frontmatter with a `type`. `examples/stylegallery-homepage/README.md` shipped in 0.1.4 without frontmatter, so repo validation and the `Validate StyleGallery` workflow (`.github/workflows/validate.yml`, `node scripts/validate-okf.mjs --json`) fail on `main`.

This adds the frontmatter block, matching the convention already used by `README.md` (`type: Repository Guide`) and `consumer-reference/agent-native/README.md` (`type: Interface Guide`). No prose or validator changes.

Verified locally on top of `upstream/main` (9049f13):

```
$ node scripts/validate-okf.mjs --json
{ "ok": true, "conceptCount": 110, "indexCount": 25, "logCount": 1, "failures": [] }

$ node scripts/test-validate-okf.mjs --json
ok: true
```

Not verified: the rest of `validate.yml` beyond the OKF steps.